### PR TITLE
Convert clblob console.html from jQuery to Mithril.js

### DIFF
--- a/clblob/console.html
+++ b/clblob/console.html
@@ -627,6 +627,11 @@ function update_status(replica) {
         update_summary();
 
         update_replica_usage(status.cluster, status.bucket);
+
+        // TODO: Remove wastefully throwing away a generated div to ensure maximumWarningSeverity is correct
+        // Otherwise, some labels may have incorrect CSS status because they depend
+        // on maximum warning severity calculations in metric function
+        generate_replica_status_success_div(replica);
     }
 }
 
@@ -682,6 +687,7 @@ function generate_replica_status_success_div(replica) {
         ('store_disk' in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
     ];
 
+    // TODO: Improve so do not habe to store value of global replica_status which may have changed
     updateStateForReplica(replica, {maximumWarningSeverity: replica_status});
     return result;
 }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -521,6 +521,7 @@ function update_status(replica) {
 }
 
 function sync_status_help(status) {
+    var help;
     if (status.indexOf('start delay') === 0)
         return 'Sync has not been run since server start.';
     if (status.indexOf('failed') === 0)
@@ -558,6 +559,7 @@ function sync_status_help(status) {
 }
 
 function purge_status_help(status) {
+    var help;
     if (status.indexOf('start delay') === 0)
         return 'Purge has not been run since server start.';
     if (status.indexOf('failed') === 0)
@@ -580,6 +582,7 @@ function purge_status_help(status) {
 }
 
 function buffer_status_help(status) {
+    var help;
     if (status.indexOf('start delay') === 0)
         return 'Buffer has not been run since server start.';
     if (status.indexOf('failed') === 0)

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -810,6 +810,28 @@ function si_prefix(value, factor) {
 isHelpHidden = true;
 isByIPHidden = true;
 
+function generateHelpDiv() {
+    var help = {
+        b: "Run buffer on visible replicas",
+        B: "Run buffer on all replicas",
+        h: "Hide all replicas",
+        H: "Show all replicas",
+        "i/I": "Toggle ip view",
+        p: "Run purge on visible replicas",
+        P: "Run purge on all replicas",
+        "r or &lt;space&gt": "Refresh visible replicas",
+        R: "Refresh all replicas",
+        s: "Run sync on visible replicas",
+        S: "Run sync on all replicas"
+    };
+
+    return m("#help", { class: isHelpHidden ? "hide" : "nohide" }, 
+        Object.keys(help).map(function (key) {
+            return m("div", m("b", m.trust(key)), " - ", help[key])
+        })
+    );
+}
+
 function main() {
     return m("div", [
         m("#header", [
@@ -826,52 +848,7 @@ function main() {
                 m("b", "by ip")
             ])
         ]),
-        m("#help", { class: isHelpHidden ? "hide" : "nohide" }, [
-            m("div", [
-                m("b", "b"),
-                " - Run buffer on visible replicas"
-            ]),
-            m("div", [
-                m("b", "B"),
-                " - Run buffer on all replicas"
-            ]),
-            m("div", [
-                m("b", "h"),
-                " - Hide all replicas"
-            ]),
-            m("div", [
-                m("b", "H"),
-                " - Show all replicas"
-            ]),
-            m("div", [
-                m("b", "i/I"),
-                " - Toggle ip view"
-            ]),
-            m("div", [
-                m("b", "p"),
-                " - Run purge on visible replicas"
-            ]),
-            m("div", [
-                m("b", "P"),
-                " - Run purge on all replicas"
-            ]),
-            m("div", [
-                m("b", "r or ", m.trust("&lt;space&gt")),
-                " - Refresh visible replicas"
-            ]),
-            m("div", [
-                m("b", "R"),
-                " - Refresh all replicas"
-            ]),
-            m("div", [
-                m("b", "s"),
-                " - Run sync on visible replicas"
-            ]),
-            m("div", [
-                m("b", "S"),
-                " - Run sync on all replicas"
-            ])
-        ]),
+        generateHelpDiv(),
         m("#grid"),
         m("#summary"),
         m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -813,7 +813,7 @@ function si_prefix(value, factor) {
 isHelpHidden = true;
 isByIPHidden = true;
 
-function generateHelpDiv() {
+function key_help() {
     var help = {
         b: "Run buffer on visible replicas",
         B: "Run buffer on all replicas",
@@ -851,7 +851,7 @@ function main() {
                 m("b", "by ip")
             ])
         ]),
-        generateHelpDiv(),
+        key_help(),
         m("#grid"),
         m("#summary"),
         m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -158,8 +158,6 @@ div.updating {
         <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
 
-$(document).ready(get_config);
-
 function get_config() {
     m.request({url: '/_config'}).then(update_config);
 }
@@ -196,7 +194,6 @@ function update_config(data) {
         }
     }
 
-    $('#grid').html(grid());
     $('#by_ip').html(iterate_sorted_object(by_ip, combine_ips));
     $('#main').html(main());
 
@@ -208,39 +205,36 @@ function update_config(data) {
 }
 
 function grid() {
-    var grid = '';
-
-    grid += '<div class="group">';
-    for (var cluster = 0; cluster < clusters.length; cluster++) {
-        grid += '<div class="grid_cluster">' +
-            '<div class="group">' +
-            '<div class="name"><b>cluster ' + cluster + '</b></div>' +
-            '</div>' +
-            '<div class="group">';
-
-        var buckets = clusters[cluster];
-        for (var bucket = 0; bucket < buckets.length; bucket++) {
-            grid += '<div class="grid_bucket">' +
-                '<div class="grid_bucket_number">' + bucket + '</div>';
-
-            var replicas = buckets[bucket].replicas;
-            for (var replica = 0; replica < replicas.length; replica++) {
-                grid += hover_help(
-                    '<a href="#bucket_' + cluster + '_' + bucket + '" ' +
-                    'onclick="$(\'#replica_' + replicas[replica] + '\')' +
-                    '.parent().children(\'div.replica\')' +
-                    '.removeClass(\'hide\');">' +
-                    '<div id="grid_replica_' + replicas[replica] +
-                    '" class="grid_replica"></div></a>',
-                    replicas[replica]);
-            }
-            grid += '</div>';
-        }
-        grid += '</div></div>';
-    }
-    grid += '</div>';
-
-   return grid;
+    return m(".group",
+        clusters.map(function (cluster, clusterIndex) {
+            return m(".grid_cluster", 
+                m(".group", 
+                    m(".name", m("b", "cluster ", clusterIndex))
+                ),
+                m(".group", 
+                    cluster.map(function (bucket, bucketIndex) {
+                        return m(".grid_bucket", 
+                            m(".grid_bucket_number", bucketIndex),
+                            bucket.replicas.map(function (replica, replicaIndex) {
+                                return m_hover_help(
+                                    m("a", 
+                                        {
+                                            href: "#bucket_" + clusterIndex + '_' + bucketIndex,
+                                            onclick: function() {
+                                                // TODO: Store open/close state in domain not DOM
+                                                $('#replica_' + replica).parent().children('div.replica').removeClass('hide');
+                                            }
+                                        }, 
+                                        m(".grid_replica#grid_replica_" + replica)
+                                    ),
+                                    replica
+                                )
+                        }))
+                    })
+                )
+            )
+        })
+    );
 }
 
 function main() {
@@ -775,6 +769,10 @@ function hover_help(content, help_text) {
         '<div class="hover_help">' + help_text + '</div></span>';
 }
 
+function m_hover_help(content, help_text) {
+    return m("span.hover_help_wrapper", content, m(".hover_help", help_text));
+}
+
 function iterate_sorted_object(key_values, callback) {
     var keys = [];
     var key;
@@ -887,7 +885,7 @@ function body() {
             ])
         ]),
         key_help(),
-        m("#grid"),
+        m("#grid", grid()),
         m("#summary"),
         m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),
         m("#main")
@@ -896,6 +894,6 @@ function body() {
         </script>
     </head>
     <body>
-        <script>m.mount(document.body, {view: body});</script>
+        <script>m.mount(document.body, {view: body}); get_config();</script>
     </body>
 </html>

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -157,6 +157,8 @@ div.updating {
         <script src="_jquery.js"></script>
         <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
+/* global m, $ */
+"use strict";
 
 function get_config() {
     m.request({url: '/_config'}).then(update_config);
@@ -259,7 +261,7 @@ function main() {
                             return m(".metric#replica_name_" + replica,
                                 m("b", replica)
                             )
-                        }),
+                        })
                     ),
                     replica_main(bucket.replicas)
                 )
@@ -295,7 +297,7 @@ function combine_ports(port, replica) {
 
 function foreach_replica(callback, filter) {
     for (var index = 0; index < refresh_replicas.length; index++) {
-        replica = refresh_replicas[index];
+        var replica = refresh_replicas[index];
         if (filter === true) {
             if ($('#replica_' + replica).hasClass('hide'))
                 continue;
@@ -353,7 +355,7 @@ function handle_keypress(event) {
 
 function flush_status() {
     while (running_status < 8) {
-        replica = queued_status.shift();
+        var replica = queued_status.shift();
         if (!replica)
             break;
         running_status++;
@@ -812,8 +814,8 @@ function get_notify_class(value, warning, critical) {
     return '';
 }
 
-SI_PREFIXES_LARGE = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-SI_PREFIXES_SMALL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y'];
+var SI_PREFIXES_LARGE = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+var SI_PREFIXES_SMALL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y'];
 
 function si_prefix(value, factor) {
     if (factor === null)
@@ -842,8 +844,8 @@ function si_prefix(value, factor) {
     return (Math.round(value * adjust) / adjust) + prefix;
 }
 
-isHelpHidden = true;
-isByIPHidden = true;
+var isHelpHidden = true;
+var isByIPHidden = true;
 
 function key_help() {
     var help = {
@@ -890,9 +892,14 @@ function body() {
         m("#main", main())
     ]);
 }
+
+function start() {
+   m.mount(document.body, {view: body});
+   get_config(); 
+}
         </script>
     </head>
     <body>
-        <script>m.mount(document.body, {view: body}); get_config();</script>
+        <script>/* global start */ start();</script>
     </body>
 </html>

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -155,12 +155,13 @@ div.updating {
 
         </style>
         <script src="_jquery.js"></script>
+        <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
 
 $(document).ready(get_config);
 
 function get_config() {
-    $.getJSON('/_config', update_config);
+    m.request({url: '/_config'}).then(update_config);
 }
 
 var config;
@@ -806,34 +807,80 @@ function si_prefix(value, factor) {
     return (Math.round(value * adjust) / adjust) + prefix;
 }
 
+isHelpHidden = true;
+isByIPHidden = true;
+
+function main() {
+    return m("div", [
+        m("#header", [
+            m("h1", m.trust("&#9774;"), " craigslist blob console"),
+            m("a.clickable", {
+                onclick: function() { isHelpHidden = !isHelpHidden; console.log("isHelpHidden", isHelpHidden); },
+            }, [
+                m("b", "shortcuts")
+            ]),
+            " - ",
+            m("a.clickable", {
+                onclick: function() { isByIPHidden = !isByIPHidden; },
+            }, [
+                m("b", "by ip")
+            ])
+        ]),
+        m("#help", { class: isHelpHidden ? "hide" : "nohide" }, [
+            m("div", [
+                m("b", "b"),
+                " - Run buffer on visible replicas"
+            ]),
+            m("div", [
+                m("b", "B"),
+                " - Run buffer on all replicas"
+            ]),
+            m("div", [
+                m("b", "h"),
+                " - Hide all replicas"
+            ]),
+            m("div", [
+                m("b", "H"),
+                " - Show all replicas"
+            ]),
+            m("div", [
+                m("b", "i/I"),
+                " - Toggle ip view"
+            ]),
+            m("div", [
+                m("b", "p"),
+                " - Run purge on visible replicas"
+            ]),
+            m("div", [
+                m("b", "P"),
+                " - Run purge on all replicas"
+            ]),
+            m("div", [
+                m("b", "r or ", m.trust("&lt;space&gt")),
+                " - Refresh visible replicas"
+            ]),
+            m("div", [
+                m("b", "R"),
+                " - Refresh all replicas"
+            ]),
+            m("div", [
+                m("b", "s"),
+                " - Run sync on visible replicas"
+            ]),
+            m("div", [
+                m("b", "S"),
+                " - Run sync on all replicas"
+            ])
+        ]),
+        m("#grid"),
+        m("#summary"),
+        m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),
+        m("#main")
+    ]);
+}
         </script>
     </head>
     <body>
-        <div id="header">
-            <h1>&#9774; craigslist blob console</h1>
-            <a class="clickable" onclick="$('#help').toggleClass('hide');">
-                <b>shortcuts</b>
-            </a> -
-            <a class="clickable" onclick="$('#by_ip').toggleClass('hide');">
-                <b>by ip</b>
-            </a>
-        </div>
-        <div id="help" class="hide">
-            <div><b>b</b> - Run buffer on visible replicas</div>
-            <div><b>B</b> - Run buffer on all replicas</div>
-            <div><b>h</b> - Hide all replicas</div>
-            <div><b>H</b> - Show all replicas</div>
-            <div><b>i/I</b> - Toggle ip view</div>
-            <div><b>p</b> - Run purge on visible replicas</div>
-            <div><b>P</b> - Run purge on all replicas</div>
-            <div><b>r or &lt;space&gt;</b> - Refresh visible replicas</div>
-            <div><b>R</b> - Refresh all replicas</div>
-            <div><b>s</b> - Run sync on visible replicas</div>
-            <div><b>S</b> - Run sync on all replicas</div>
-        </div>
-        <div id="grid"></div>
-        <div id="summary"></div>
-        <div id="by_ip" class="hide"></div>
-        <div id="main"></div>
+        <script>m.mount(document.body, {view: main});</script>
     </body>
 </html>

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -216,7 +216,7 @@ function updateStateForReplica(replica, newState) {
 }
 
 function updateStateForAllReplicas(newState) {
-    for (let replica in stateForReplica) {
+    for (var replica in stateForReplica) {
         var state = getStateForReplica(replica);
         for (var key in newState) {
             state[key] = newState[key];
@@ -245,7 +245,7 @@ function getStateForBucketReplicas(bucket) {
 function getReplicaLabelCSSClasses(replica) {
     var state = getStateForReplica(replica);
     var severity = "." + state.maximumWarningSeverity;
-    var updating = state.updating ? ".updating" : ""
+    var updating = state.updating ? ".updating" : "";
     return severity + updating;
 }
 
@@ -259,7 +259,7 @@ function getReplicaLabel(replica, type) {
     return m("." + type + ".replica_name_" + replica + getReplicaLabelCSSClasses(replica), 
         m("b", replica, possibleColonForRelativeUsagePercent),
         relativeUsagePercentText
-    )
+    );
 }
 
 function update_config(data) {
@@ -308,11 +308,11 @@ function grid() {
                                         m(".grid_replica#grid_replica_" + replica + getReplicaLabelCSSClasses(replica))
                                     ),
                                     replica
-                                )
-                        }))
+                                );
+                        }));
                     })
                 )
-            )
+            );
         })
     );
 }
@@ -342,9 +342,9 @@ function main() {
                         })
                     ),
                     replica_main(bucket.replicas)
-                )
+                );
             })
-        )
+        );
     });
 }
 
@@ -359,7 +359,7 @@ function replica_main(replicas) {
         } else {
             innerDiv = m(".group", 
                 getReplicaLabel(replica, "name")
-            )
+            );
         }
 
         var state = getStateForReplica(replica);
@@ -367,7 +367,7 @@ function replica_main(replicas) {
         var warningClass = state.requestResult === "error" ? ".warning" : "";
         return m(".replica#replica_" + replica + hideClass + warningClass,
             innerDiv
-        )
+        );
     });
 }
 
@@ -377,7 +377,7 @@ function combine_ips(ip, ports) {
             m(".name", m("b", "ip " + ip)),
             iterate_sorted_object(ports, combine_ports)
         )
-    )
+    );
 }
 
 function combine_ports(port, replica) {
@@ -444,7 +444,7 @@ function handle_keypress(event) {
             m.request({
                 url: url + replica, 
                 method: "GET",
-                config: function(xhr) { xhr.timeout = replica_timeout; },
+                config: configXHRTimeout,
                 // Don't try to convert the result to JSON
                 deserialize: function(value) { return value; }
             });
@@ -452,6 +452,10 @@ function handle_keypress(event) {
     }
     else
         refresh(filter);
+}
+
+function configXHRTimeout(xhr) {
+    xhr.timeout = replica_timeout;
 }
 
 function flush_status() {
@@ -464,7 +468,7 @@ function flush_status() {
         m.request({
             url: '/_status/' + replica,
             method: "GET",
-            config: function(xhr) { xhr.timeout = replica_timeout; }
+            config: configXHRTimeout
         })
         .then(update_status(replica))
         .catch(update_status_fail(replica));
@@ -554,7 +558,7 @@ function update_summary_metrics(name, details) {
         usage: usage,
         total: total,
         count: count
-    }
+    };
 }
 
 function summary_metrics(name, details) {
@@ -588,13 +592,13 @@ function update_replica_usage(cluster, bucket) {
         var relative = (replica_usage[replica] / max_usage) * 100;
 
         var relativeUsagePercent = Math.round(relative);
-        updateStateForReplica(replica, {relativeUsagePercent: relativeUsagePercent})
+        updateStateForReplica(replica, {relativeUsagePercent: relativeUsagePercent});
 
         var severity = getStateForReplica(replica).maximumWarningSeverity;
 
         // If a replica's relativeUsagePercent is lagging behind the other replicas, it may be experiencing issues, so warn
         if (relative < 98 && severity !== "critical") {
-            updateStateForReplica(replica, {maximumWarningSeverity: "warning"})
+            updateStateForReplica(replica, {maximumWarningSeverity: "warning"});
         }
     }
 }
@@ -632,7 +636,7 @@ function update_status(replica) {
         // Otherwise, some labels may have incorrect CSS status because they depend
         // on maximum warning severity calculations in metric function
         generate_replica_status_success_div(replica);
-    }
+    };
 }
 
 function generate_replica_status_success_div(replica) {
@@ -655,7 +659,7 @@ function generate_replica_status_success_div(replica) {
             button('sync', '/_sync/' + replica, true),
             hover_help(
                 metric('sync status', status.sync_status, 0, 0, null, sync_status_severity),
-                sync_status_help(status.sync_status),
+                sync_status_help(status.sync_status)
             ),
 
             button('purge', '/_purge/' + replica, true),
@@ -885,7 +889,7 @@ function update_status_fail(replica) {
             maximumWarningSeverity: "critical", 
             updating: false
         });
-    }
+    };
 }
 
 function generate_replica_status_fail_div(replica) {
@@ -907,7 +911,7 @@ function button(name, url, background) {
                 m.request({
                     url: url,
                     method: "GET",
-                    config: function(xhr) { xhr.timeout = replica_timeout; },
+                    config: configXHRTimeout,
                     // Don't try to convert the result to JSON
                     deserialize: function(value) { return value; }
                 });
@@ -1036,7 +1040,7 @@ function key_help() {
 
     return m("#help", { class: isHelpHidden ? "hide" : "nohide" }, 
         Object.keys(help).map(function (key) {
-            return m("div", m("b", m.trust(key)), " - ", help[key])
+            return m("div", m("b", m.trust(key)), " - ", help[key]);
         })
     );
 }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -154,7 +154,7 @@ div.updating {
 }
 
         </style>
-        // TODO: IMPORTANT For production use, mithril.js should be a local file like jQuery was
+        <!-- TODO: IMPORTANT For production use, mithril.js should be a local file like jQuery was -->
         <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
 /* global m */

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -160,26 +160,27 @@ div.updating {
 /* global m, window, document, location, setTimeout */
 /* jshint sub: true */
 /* jshint -W097 */
-"use strict";
+/* jshint asi: true */
+"use strict"
 
 function get_config() {
-    m.request({url: "/_config"}).then(update_config);
+    m.request({url: "/_config"}).then(update_config)
 }
 
-var config;
-var refresh_replicas = [];
-var refresh_timer;
-var refresh_auto_ms = 60000;
-var keypress_max_ms = 1000;
-var last_keypress = 0;
-var running_status = 0;
-var queued_status = [];
-var replica_usage = {};
-var replica_timeout = 2000;
+var config
+var refresh_replicas = []
+var refresh_timer
+var refresh_auto_ms = 60000
+var keypress_max_ms = 1000
+var last_keypress = 0
+var running_status = 0
+var queued_status = []
+var replica_usage = {}
+var replica_timeout = 2000
 
-var clusters = [];
-var allReplicasByName = {};
-var allReplicasByIP = {};
+var clusters = []
+var allReplicasByName = {}
+var allReplicasByIP = {}
 
 // stateForReplica stores the last known state for a replica
 // its contents are: 
@@ -191,10 +192,10 @@ var allReplicasByIP = {};
 //    updating: boolean,
 //    relativeUsagePercent: number
 //}
-var stateForReplica = {};
+var stateForReplica = {}
 
 function getStateForReplica(replica) {
-    var state = stateForReplica[replica];
+    var state = stateForReplica[replica]
     if (!state) {
         state = {
             requestResult: null, 
@@ -203,88 +204,88 @@ function getStateForReplica(replica) {
             maximumWarningSeverity: "ok",
             updating: false,
             relativeUsagePercent: null
-        };
-        stateForReplica[replica] = state;
+        }
+        stateForReplica[replica] = state
     }
-    return state;
+    return state
 }
 
 // Will only change keys supplied in newState and leave others as they were
 function updateStateForReplica(replica, newState) {
-    var state = getStateForReplica(replica);
+    var state = getStateForReplica(replica)
     for (var key in newState) {
-        state[key] = newState[key];
+        state[key] = newState[key]
     }
 }
 
 function updateStateForAllReplicas(newState) {
     for (var replica in stateForReplica) {
-        var state = getStateForReplica(replica);
+        var state = getStateForReplica(replica)
         for (var key in newState) {
-            state[key] = newState[key];
+            state[key] = newState[key]
         }
     }
 }
 
 function updateStateForBucketReplicas(bucket, newState) {
     bucket.replicas.map(function (replica) {
-        var state = getStateForReplica(replica);
+        var state = getStateForReplica(replica)
         for (var key in newState) {
-            state[key] = newState[key];
+            state[key] = newState[key]
         }
-    });
+    })
 }
 
 function getStateForBucketReplicas(bucket) {
-    var result = [];
+    var result = []
     bucket.replicas.map(function (replica) {
-        var state = getStateForReplica(replica);
-        result.push(state);
-    });
-    return result;
+        var state = getStateForReplica(replica)
+        result.push(state)
+    })
+    return result
 }
 
 function getReplicaLabelCSSClasses(replica) {
-    var state = getStateForReplica(replica);
-    var severity = "." + state.maximumWarningSeverity;
-    var updating = state.updating ? ".updating" : "";
-    return severity + updating;
+    var state = getStateForReplica(replica)
+    var severity = "." + state.maximumWarningSeverity
+    var updating = state.updating ? ".updating" : ""
+    return severity + updating
 }
 
 // type is name or metric
 // Label generated may include relative usage percent if available.
 // Label will also include warning classes if needed.
 function getReplicaLabel(replica, type) {
-    var relativeUsagePercent = getStateForReplica(replica).relativeUsagePercent;
-    var relativeUsagePercentText = relativeUsagePercent === null ? "" : " " + relativeUsagePercent + "%";
-    var possibleColonForRelativeUsagePercent = relativeUsagePercent === null ? "" : ":";
+    var relativeUsagePercent = getStateForReplica(replica).relativeUsagePercent
+    var relativeUsagePercentText = relativeUsagePercent === null ? "" : " " + relativeUsagePercent + "%"
+    var possibleColonForRelativeUsagePercent = relativeUsagePercent === null ? "" : ":"
     return m("." + type + ".replica_name_" + replica + getReplicaLabelCSSClasses(replica), 
         m("b", replica, possibleColonForRelativeUsagePercent),
         relativeUsagePercentText
-    );
+    )
 }
 
 function update_config(data) {
-    config = data;
-    clusters = config.clblob.client.clusters;
-    allReplicasByName = config.clblob.client.replicas;
+    config = data
+    clusters = config.clblob.client.clusters
+    allReplicasByName = config.clblob.client.replicas
     
     for (var clusterIndex = 0; clusterIndex < clusters.length; clusterIndex++) {
-        var buckets = clusters[clusterIndex];
+        var buckets = clusters[clusterIndex]
         for (var bucketIndex = 0; bucketIndex < buckets.length; bucketIndex++) {
-            var replicasInBucket = buckets[bucketIndex].replicas;
+            var replicasInBucket = buckets[bucketIndex].replicas
             for (var replicaIndex = 0; replicaIndex < replicasInBucket.length; replicaIndex++) {
-                var replica = replicasInBucket[replicaIndex];
-                var ip = allReplicasByName[replica].ip;
-                var port = allReplicasByName[replica].port;
-                if (!allReplicasByIP[ip]) allReplicasByIP[ip] = {};
-                allReplicasByIP[ip][port] = replica;
-                refresh_replicas.push(replica);
+                var replica = replicasInBucket[replicaIndex]
+                var ip = allReplicasByName[replica].ip
+                var port = allReplicasByName[replica].port
+                if (!allReplicasByIP[ip]) allReplicasByIP[ip] = {}
+                allReplicasByIP[ip][port] = replica
+                refresh_replicas.push(replica)
             }
         }
     }
 
-    refresh();
+    refresh()
 }
 
 function grid() {
@@ -304,19 +305,19 @@ function grid() {
                                         {
                                             href: "#bucket_" + clusterIndex + "_" + bucketIndex,
                                             onclick: function() {
-                                                updateStateForBucketReplicas(bucket, {hidden: false});
+                                                updateStateForBucketReplicas(bucket, {hidden: false})
                                             }
                                         }, 
                                         m(".grid_replica#grid_replica_" + replica + getReplicaLabelCSSClasses(replica))
                                     ),
                                     replica
-                                );
-                        }));
+                                )
+                        }))
                     })
                 )
-            );
+            )
         })
-    );
+    )
 }
 
 function main() {
@@ -332,7 +333,7 @@ function main() {
                     m(".group.clickable", 
                         {
                             onclick: function(event) {
-                                updateStateForBucketReplicas(bucket, {hidden: !getStateForBucketReplicas(bucket)[0].hidden});
+                                updateStateForBucketReplicas(bucket, {hidden: !getStateForBucketReplicas(bucket)[0].hidden})
                             }
                         }, 
                         m(".name",
@@ -340,37 +341,37 @@ function main() {
                         ),
                         metric("write weight", bucket.write_weight, 0, 0, null, 0),
                         bucket.replicas.map(function (replica, replicaIndex) {
-                            return getReplicaLabel(replica, "metric");
+                            return getReplicaLabel(replica, "metric")
                         })
                     ),
                     replica_main(bucket.replicas)
-                );
+                )
             })
-        );
-    });
+        )
+    })
 }
 
 function replica_main(replicas) {
     return replicas.map(function (replica, replicaIndex) {
-        var requestResult = getStateForReplica(replica).requestResult;
-        var innerDiv;
+        var requestResult = getStateForReplica(replica).requestResult
+        var innerDiv
         if (requestResult === "success") {
-            innerDiv = generate_replica_status_success_div(replica);
+            innerDiv = generate_replica_status_success_div(replica)
         } else if (requestResult === "error") {
-            innerDiv = generate_replica_status_fail_div(replica);
+            innerDiv = generate_replica_status_fail_div(replica)
         } else {
             innerDiv = m(".group", 
                 getReplicaLabel(replica, "name")
-            );
+            )
         }
 
-        var state = getStateForReplica(replica);
-        var hideClass = state.hidden ? ".hide" : "";
-        var warningClass = state.requestResult === "error" ? ".warning" : "";
+        var state = getStateForReplica(replica)
+        var hideClass = state.hidden ? ".hide" : ""
+        var warningClass = state.requestResult === "error" ? ".warning" : ""
         return m(".replica#replica_" + replica + hideClass + warningClass,
             innerDiv
-        );
-    });
+        )
+    })
 }
 
 function combine_ips(ip, ports) {
@@ -379,23 +380,23 @@ function combine_ips(ip, ports) {
             m(".name", m("b", "ip " + ip)),
             iterate_sorted_object(ports, combine_ports)
         )
-    );
+    )
 }
 
 function combine_ports(port, replica) {
-    return getReplicaLabel(replica, "metric");
+    return getReplicaLabel(replica, "metric")
 }
 
 function foreach_replica(callback, filter) {
     for (var index = 0; index < refresh_replicas.length; index++) {
-        var replica = refresh_replicas[index];
+        var replica = refresh_replicas[index]
         if (filter === true) {
             if (getStateForReplica(replica).hidden)
-                continue;
+                continue
         }
         else if (filter && filter !== replica)
-            continue;
-        callback(replica);
+            continue
+        callback(replica)
     }
 }
 
@@ -404,42 +405,42 @@ function handle_keypress(event) {
     // This redraw is needed because this event handler is setup outside of Mithril
     // There are a some key presses that don"t require an redraw, 
     // but it is clearer to just always do a redraw for now unless there is a performance issue
-    setTimeout(m.redraw, 0);
+    setTimeout(m.redraw, 0)
 
     if (event.ctrlKey)
-        return;
+        return
     if (event.which === 104) {
-        updateStateForAllReplicas({hidden: true});
-        return;
+        updateStateForAllReplicas({hidden: true})
+        return
     }
     if (event.which === 72) {
-        updateStateForAllReplicas({hidden: false});
-        return;
+        updateStateForAllReplicas({hidden: false})
+        return
     }
     if (event.which === 73 || event.which === 105) {
-        isByIPHidden = !isByIPHidden;
-        return;
+        isByIPHidden = !isByIPHidden
+        return
     }
-    var url;
-    var upper_key = event.which & 95;
-    var filter = event.which === 32 || event.which >= 97;
+    var url
+    var upper_key = event.which & 95
+    var filter = event.which === 32 || event.which >= 97
     if (upper_key === 82 || event.which === 32)
-        url = null;
+        url = null
     if (upper_key === 66)
-        url = "/_buffer/";
+        url = "/_buffer/"
     if (upper_key === 80)
-        url = "/_purge/";
+        url = "/_purge/"
     if (upper_key === 83)
-        url = "/_sync/";
+        url = "/_sync/"
     if (url === undefined)
-        return;
+        return
 
-    event.preventDefault();
+    event.preventDefault()
 
-    var current = Math.round(new Date().getTime() / keypress_max_ms);
+    var current = Math.round(new Date().getTime() / keypress_max_ms)
     if (current === last_keypress)
-        return;
-    last_keypress = current;
+        return
+    last_keypress = current
 
     if (url !== null) {
         foreach_replica(function (replica) {
@@ -448,55 +449,55 @@ function handle_keypress(event) {
                 method: "GET",
                 config: configXHRTimeout,
                 // Don't try to convert the result to JSON
-                deserialize: function(value) { return value; }
-            });
-        }, filter);
+                deserialize: function(value) { return value }
+            })
+        }, filter)
     }
     else
-        refresh(filter);
+        refresh(filter)
 }
 
 function configXHRTimeout(xhr) {
-    xhr.timeout = replica_timeout;
+    xhr.timeout = replica_timeout
 }
 
 function flush_status() {
     while (running_status < 8) {
-        var replica = queued_status.shift();
+        var replica = queued_status.shift()
         if (!replica)
-            break;
-        running_status++;
-        updateStateForReplica(replica, {updating: true});
+            break
+        running_status++
+        updateStateForReplica(replica, {updating: true})
         m.request({
             url: "/_status/" + replica,
             method: "GET",
             config: configXHRTimeout
         })
         .then(update_status(replica))
-        .catch(update_status_fail(replica));
+        .catch(update_status_fail(replica))
     }
 }
 
 function refresh(filter) {
     if (!filter && refresh_timer)
-        window.clearTimeout(refresh_timer);
+        window.clearTimeout(refresh_timer)
     foreach_replica(function (replica) {
         if (filter)
-            queued_status.unshift(replica);
+            queued_status.unshift(replica)
         else
-            queued_status.push(replica);
+            queued_status.push(replica)
         },
-        filter);
-    flush_status();
+        filter)
+    flush_status()
     if (!filter) {
         refresh_timer = window.setTimeout(
             function () {
-                refresh();
+                refresh()
                 // timeouts need to call m.redraw if they could affect drawable state
-                m.redraw();
+                m.redraw()
             },
             refresh_auto_ms
-        );
+        )
     }
 }
 
@@ -529,78 +530,78 @@ var summary = {
         warning: 1000,
         help_text: "The total number of events queued to a replica across all replicas."
     }
-};
+}
 
 function update_summary() {
-    iterate_sorted_object(summary, update_summary_metrics);
+    iterate_sorted_object(summary, update_summary_metrics)
 }
 
 function generate_summary_div() {
     return m(".group",
         m(".name", m("b", "summary")),
         iterate_sorted_object(summary, summary_metrics)
-    );
+    )
 }
 
 function update_summary_metrics(name, details) {
-    var usage = 0;
-    var total = 0;
-    var count = 0;
+    var usage = 0
+    var total = 0
+    var count = 0
     for (var replica in details["values"]) {
-        count++;
+        count++
         if (details["type"] === "usage") {
-            usage += details["values"][replica][0];
-            total += details["values"][replica][1];
+            usage += details["values"][replica][0]
+            total += details["values"][replica][1]
         }
         else
-            total += details["values"][replica];
+            total += details["values"][replica]
     }
     // Add storage object into summary data structure for later use when generating summary metrics divs
     details._replicaStats = {
         usage: usage,
         total: total,
         count: count
-    };
+    }
 }
 
 function summary_metrics(name, details) {
     if (!details._replicaStats || details._replicaStats.count === 0)
-        return "";
+        return ""
     if (details["type"] === "usage")
         return hover_help(
             usage_metric(name, details._replicaStats.total, details._replicaStats.usage, 60, 80, details["factor"]),
             details["help_text"]
-        );
+        )
     return hover_help(
         metric(name, details._replicaStats.total, details["warning"], details["critical"], details["factor"]),
         details["help_text"]
-    );
+    )
 }
 
 function update_replica_usage(cluster, bucket) {
-    var replicaIndex;
-    var replicas = clusters[cluster][bucket].replicas;
-    var max_usage = 0;
+    var replicaIndex
+    var replicas = clusters[cluster][bucket].replicas
+    var max_usage = 0
     for (replicaIndex = 0; replicaIndex < replicas.length; replicaIndex++) {
         if (max_usage < replica_usage[replicas[replicaIndex]])
-            max_usage = replica_usage[replicas[replicaIndex]];
+            max_usage = replica_usage[replicas[replicaIndex]]
     }
     if (max_usage === 0)
-        return;
+        return
     for (replicaIndex = 0; replicaIndex < replicas.length; replicaIndex++) {
-        var replica = replicas[replicaIndex];
+        var replica = replicas[replicaIndex]
         if (replica_usage[replica] === undefined)
-            continue;
-        var relative = (replica_usage[replica] / max_usage) * 100;
+            continue
+        var relative = (replica_usage[replica] / max_usage) * 100
 
-        var relativeUsagePercent = Math.round(relative);
-        updateStateForReplica(replica, {relativeUsagePercent: relativeUsagePercent});
+        var relativeUsagePercent = Math.round(relative)
+        updateStateForReplica(replica, {relativeUsagePercent: relativeUsagePercent})
 
-        var severity = getStateForReplica(replica).maximumWarningSeverity;
+        var severity = getStateForReplica(replica).maximumWarningSeverity
 
         // If a replica's relativeUsagePercent is lagging behind the other replicas, it may be experiencing issues, so warn
         if (relative < 98 && severity !== "critical") {
-            updateStateForReplica(replica, {maximumWarningSeverity: "warning"});
+            updateStateForReplica(replica, {maximumWarningSeverity: "warning"})
         }
     }
 }
@@ -608,47 +609,47 @@ function update_replica_usage(cluster, bucket) {
 // TODO: Remove replica_status global
 // This global is updated through the process of generating the status display.
 // It is the maximum severity of all the status warnings for a replica.
-var replica_status;
+var replica_status
 
 function update_status(replica) {
     return function (status) {
-        flush_status();
-        running_status--;
+        flush_status()
+        running_status--
         
         updateStateForReplica(replica, {
             requestResult: "success", 
             status: status, 
             maximumWarningSeverity: "ok", 
             updating: false
-        });
+        })
 
-        summary["replica events"]["values"][replica] = 0;
-        iterate_sorted_object(status.replicas, update_replica_metrics(replica));
+        summary["replica events"]["values"][replica] = 0
+        iterate_sorted_object(status.replicas, update_replica_metrics(replica))
 
-        summary["cluster events"]["values"][replica] = 0;
-        iterate_sorted_object(status.clusters, update_cluster_metrics(replica));
+        summary["cluster events"]["values"][replica] = 0
+        iterate_sorted_object(status.clusters, update_cluster_metrics(replica))
         
-        if ("store_disk" in status) update_store_disk_metrics(replica, status.store_disk);
+        if ("store_disk" in status) update_store_disk_metrics(replica, status.store_disk)
 
-        update_summary();
+        update_summary()
 
-        update_replica_usage(status.cluster, status.bucket);
+        update_replica_usage(status.cluster, status.bucket)
 
         // TODO: Remove wastefully throwing away a generated div to ensure maximumWarningSeverity is correct
         // Otherwise, some labels may have incorrect CSS status because they depend
         // on maximum warning severity calculations in metric function
-        generate_replica_status_success_div(replica);
-    };
+        generate_replica_status_success_div(replica)
+    }
 }
 
 function generate_replica_status_success_div(replica) {
     // TODO: This replica_status global is updated as a side effect of generating displays for metrics
-    replica_status = "ok";
-    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port;
-    var status = getStateForReplica(replica).status;
-    var sync_status_severity = (status.sync_status || "").indexOf("failed") === 0 ? 1 : 0;
-    var purge_status_severity = (status.purge_status || "").indexOf("failed") === 0 ? 1 : 0;
-    var buffer_status_severity = (status.buffer_status || "").indexOf("failed") === 0 ? 1 : 0;
+    replica_status = "ok"
+    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port
+    var status = getStateForReplica(replica).status
+    var sync_status_severity = (status.sync_status || "").indexOf("failed") === 0 ? 1 : 0
+    var purge_status_severity = (status.purge_status || "").indexOf("failed") === 0 ? 1 : 0
+    var buffer_status_severity = (status.buffer_status || "").indexOf("failed") === 0 ? 1 : 0
     var result = [
         m(".group",
             getReplicaLabel(replica, "name"),
@@ -691,92 +692,92 @@ function generate_replica_status_success_div(replica) {
 
         ("index_sqlite" in status) ? m(".group", index_sqlite_metrics(replica, status.index_sqlite)) : [],
         ("store_disk" in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
-    ];
+    ]
 
     // TODO: Improve so do not have to store value of global replica_status which may have changed
-    updateStateForReplica(replica, {maximumWarningSeverity: replica_status});
-    return result;
+    updateStateForReplica(replica, {maximumWarningSeverity: replica_status})
+    return result
 }
 
 function sync_status_help(status) {
-    var help;
+    var help
     if (status.indexOf("start delay") === 0)
-        return "Sync has not been run since server start.";
+        return "Sync has not been run since server start."
     if (status.indexOf("failed") === 0)
-        return "Sync failed to complete.";
+        return "Sync failed to complete."
     if (status.indexOf("local checksums") === 0)
         help = "Sync is running and is currently computing a list of " +
-            "checksums for this replica.";
+            "checksums for this replica."
     else if (status.indexOf("source checksums") === 0)
         help = "Sync is running and is currently computing a list of " +
-            "checksums for a peer replica.";
+            "checksums for a peer replica."
     else if (status.indexOf("diff checksums") === 0)
         help = "Sync is running and is currently comparing a list of " +
-            "checksums between this replica and a peer replica.";
+            "checksums between this replica and a peer replica."
     else if (status.indexOf("local blobs") === 0)
         help = "Sync is running and is currently getting a list of blobs " +
-            "for this replica.";
+            "for this replica."
     else if (status.indexOf("source blobs") === 0)
         help = "Sync is running and is currently getting a list of blobs " +
-            "for a peer replica.";
+            "for a peer replica."
     else if (status.indexOf("diff blobs") === 0)
         help = "Sync is running and is currently comparing a list of blobs " +
-            "between this replica and a peer replica.";
+            "between this replica and a peer replica."
     else if (status.indexOf("put") === 0)
         help = "Sync is running and is currently grabbing a blob from a " +
-            "peer to put into this replica.";
+            "peer to put into this replica."
     else if (status.indexOf("delete") === 0)
         help = "Sync is running and is currently updating the delete time " +
-            "for a blob in this replica.";
+            "for a blob in this replica."
     else if (status.indexOf("synced") === 0)
-        help = "Sync is done running.";
+        help = "Sync is done running."
     else
-        help = "Status of current/last sync operation.";
+        help = "Status of current/last sync operation."
     return help + " The counts are the number of blobs skipped, put, " +
-        "deleted, or failed for each peer.";
+        "deleted, or failed for each peer."
 }
 
 function purge_status_help(status) {
-    var help;
+    var help
     if (status.indexOf("start delay") === 0)
-        return "Purge has not been run since server start.";
+        return "Purge has not been run since server start."
     if (status.indexOf("failed") === 0)
-        return "Purge failed to complete.";
+        return "Purge failed to complete."
     if (status.indexOf("get_expired") === 0)
         help = "Purge is running and is currently getting a list of expired " +
-            "blobs from the index.";
+            "blobs from the index."
     else if (status.indexOf("delete") === 0)
         help = "Purge is running and is currently deleting an expired blob " +
-            "from disk.";
+            "from disk."
     else if (status.indexOf("delete_expired") === 0)
         help = "Purge is running and is currently deleting expired blobs " +
-            "from the index.";
+            "from the index."
     else if (status.indexOf("purged") === 0)
-        help = "Purge is done running.";
+        help = "Purge is done running."
     else
-        help = "Status of current/last purge operation.";
+        help = "Status of current/last purge operation."
     return help + " The count is the number of blobs that were purged " +
-            "during this run.";
+            "during this run."
 }
 
 function buffer_status_help(status) {
-    var help;
+    var help
     if (status.indexOf("start delay") === 0)
-        return "Buffer has not been run since server start.";
+        return "Buffer has not been run since server start."
     if (status.indexOf("failed") === 0)
-        help = "Buffer failed to complete.";
+        help = "Buffer failed to complete."
     if (status.indexOf("get_replica_events") === 0)
         help = "Buffer is running and is currently getting a list of " +
-            "replica events from the index to buffer into memory.";
+            "replica events from the index to buffer into memory."
     else if (status.indexOf("get_cluster_events") === 0)
         help = "Buffer is running and is currently getting a list of " +
-            "cluster events from the index to buffer into memory.";
+            "cluster events from the index to buffer into memory."
     else if (status.indexOf("buffered") === 0)
-        help = "Buffer is done running.";
+        help = "Buffer is done running."
     else
-        help = "Status of current/last buffer operation.";
+        help = "Status of current/last buffer operation."
     return help + " The counts are the number of replica/cluster events " +
-            "that could be buffered during this run.";
+            "that could be buffered during this run."
 }
 
 function index_sqlite_metrics(replica, status) {
@@ -790,15 +791,15 @@ function index_sqlite_metrics(replica, status) {
             metric("sqlite queue size", status.queue_size, 10, 20),
             "The number of events in the index thread queue."
         )
-    ];
+    ]
 }
 
 function update_store_disk_metrics(replica, status) {
     summary["disk space"]["values"][status.device_id] = 
-        [status.total_space - status.free_space, status.total_space];
+        [status.total_space - status.free_space, status.total_space]
     summary["disk inodes"]["values"][status.device_id] = 
-        [status.total_inodes - status.free_inodes, status.total_inodes];
-    replica_usage[replica] = status.total_inodes - status.free_inodes;
+        [status.total_inodes - status.free_inodes, status.total_inodes]
+    replica_usage[replica] = status.total_inodes - status.free_inodes
 }
 
 function store_disk_metrics(replica, status) {
@@ -818,20 +819,20 @@ function store_disk_metrics(replica, status) {
             metric("disk queue size", status.queue_size, 10, 20),
             "The number of events in the disk thread queue."
         )
-    ];
+    ]
 }
 
 function update_replica_metrics(summary_replica) {
     return function (replica, status) {
         if ("events" in status) {
-            summary["replica events"]["values"][summary_replica] += status.events;
+            summary["replica events"]["values"][summary_replica] += status.events
         }
-    };
+    }
 }
 
 function replica_metrics(summary_replica) {
     return function (replica, status) {
-        var replica_retry = config.clblob.client.replica_retry;
+        var replica_retry = config.clblob.client.replica_retry
         return [
             ("events" in status) ?
                 hover_help(
@@ -847,16 +848,16 @@ function replica_metrics(summary_replica) {
             ("last_failed" in status && status.last_failed < replica_retry) ?
                 metric(replica + " failed", status.last_failed, replica_retry, 0, null) :
                 []
-        ];
-    };
+        ]
+    }
 }
 
 function update_cluster_metrics(replica) {
     return function (cluster, status) {
         if ("events" in status) {
-            summary["cluster events"]["values"][replica] += status.events;
+            summary["cluster events"]["values"][replica] += status.events
         }
-    };
+    }
 }
 
 function cluster_metrics(replica) {
@@ -869,40 +870,40 @@ function cluster_metrics(replica) {
                     config.clblob.client.cluster_event_buffer_size * 10,
                     1000, status.events),
                 "The number of &lt;buffered&gt;/&lt;total&gt; events queued " +
-                    "up to go to cluster " + cluster + ".");
+                    "up to go to cluster " + cluster + ".")
         }
-        return [];
-    };
+        return []
+    }
 }
 
 function event_metrics(event, status) {
     return metric(event + " events",
         status.current + "/" + status.max + "/" + si_prefix(status.total), 250,
-        500, 1000, status.current);
+        500, 1000, status.current)
 }
 
 function update_status_fail(replica) {
     return function (status) {
-        flush_status();
-        running_status--;
+        flush_status()
+        running_status--
         updateStateForReplica(replica, {
             requestResult: "error", 
             status: status, 
             maximumWarningSeverity: "critical", 
             updating: false
-        });
-    };
+        })
+    }
 }
 
 function generate_replica_status_fail_div(replica) {
-    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port;
-    var status = getStateForReplica(replica).status;
+    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port
+    var status = getStateForReplica(replica).status
 
     return m(".group",
         getReplicaLabel(replica, "name"),
         button(address, "http://" + address + "/_console"),
         metric("failed", status.statusText, 0, 0, null, 1)
-    );
+    )
 }
 
 function button(name, url, background) {
@@ -915,27 +916,27 @@ function button(name, url, background) {
                     method: "GET",
                     config: configXHRTimeout,
                     // Don't try to convert the result to JSON
-                    deserialize: function(value) { return value; }
-                });
+                    deserialize: function(value) { return value }
+                })
             }
-        }, m("b", name));
+        }, m("b", name))
     }
     return m(".button", {
         onclick: function() {
-            location.href = url;
+            location.href = url
         }
-    }, m("b", name));
+    }, m("b", name))
 }
 
 function metric(name, value, warning, critical, factor, notify_value) {
     if (notify_value === undefined)
-        notify_value = value;
-    var notify = get_notify_class(notify_value, warning, critical);
-    return m(".metric." + notify, m("b", name + ":"), " ", si_prefix(value, factor));
+        notify_value = value
+    var notify = get_notify_class(notify_value, warning, critical)
+    return m(".metric." + notify, m("b", name + ":"), " ", si_prefix(value, factor))
 }
 
 function usage_metric(name, total, used, warning, critical, factor) {
-    var used_percent = Math.round((used / total) * 100);
+    var used_percent = Math.round((used / total) * 100)
     return metric(
         name, 
         si_prefix(used, factor) + "/" + si_prefix(total, factor) + " (" + used_percent + "%)", 
@@ -943,25 +944,25 @@ function usage_metric(name, total, used, warning, critical, factor) {
         critical,
         null,
         used_percent
-    );
+    )
 }
 
 function hover_help(content, help_text) {
-    return m("span.hover_help_wrapper", content, m(".hover_help", m.trust(help_text)));
+    return m("span.hover_help_wrapper", content, m(".hover_help", m.trust(help_text)))
 }
 
 function iterate_sorted_object(key_values, callback) {
-    var keys = [];
-    var key;
+    var keys = []
+    var key
     for (key in key_values)
-        keys.push(key);
-    keys.sort();
-    var result = [];
+        keys.push(key)
+    keys.sort()
+    var result = []
     for (key in keys) {
-        key = keys[key];
-        result.push(callback(key, key_values[key]));
+        key = keys[key]
+        result.push(callback(key, key_values[key]))
     }
-    return result;
+    return result
 }
 
 // TODO: Remove global use from this function
@@ -969,61 +970,61 @@ function iterate_sorted_object(key_values, callback) {
 function get_notify_class(value, warning, critical) {
     if (warning > critical) {
         if (value < critical) {
-            replica_status = "critical";
-            return "critical";
+            replica_status = "critical"
+            return "critical"
         }
         else if (value < warning) {
             if (replica_status !== "critical")
-                replica_status = "warning";
-            return "warning";
+                replica_status = "warning"
+            return "warning"
         }
     }
     else {
         if (value > critical) {
-            replica_status = "critical";
-            return "critical";
+            replica_status = "critical"
+            return "critical"
         }
         else if (value > warning) {
             if (replica_status !== "critical")
-                replica_status = "warning";
-            return "warning";
+                replica_status = "warning"
+            return "warning"
         }
     }
-    return "normal";
+    return "normal"
 }
 
-var SI_PREFIXES_LARGE = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"];
-var SI_PREFIXES_SMALL = ["", "m", "u", "n", "p", "f", "a", "z", "y"];
+var SI_PREFIXES_LARGE = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"]
+var SI_PREFIXES_SMALL = ["", "m", "u", "n", "p", "f", "a", "z", "y"]
 
 function si_prefix(value, factor) {
     if (factor === null)
-        return value;
+        return value
     if (factor === undefined)
-        factor = 1000;
-    var prefix = 0;
+        factor = 1000
+    var prefix = 0
     if (value >= 1) {
         while (Math.round(value) >= factor) {
-            value /= factor;
-            prefix++;
+            value /= factor
+            prefix++
         }
-        prefix = SI_PREFIXES_LARGE[prefix];
+        prefix = SI_PREFIXES_LARGE[prefix]
     }
     else if (value > 0) {
         while (value < 1) {
-            value *= factor;
-            prefix++;
+            value *= factor
+            prefix++
         }
-        prefix = SI_PREFIXES_SMALL[prefix];
+        prefix = SI_PREFIXES_SMALL[prefix]
     }
     else
-        return value;
-    var adjust = Math.pow(10, 3 - Math.round(value).toString().length);
-    adjust = Math.max(1, adjust);
-    return (Math.round(value * adjust) / adjust) + prefix;
+        return value
+    var adjust = Math.pow(10, 3 - Math.round(value).toString().length)
+    adjust = Math.max(1, adjust)
+    return (Math.round(value * adjust) / adjust) + prefix
 }
 
-var isHelpHidden = true;
-var isByIPHidden = true;
+var isHelpHidden = true
+var isByIPHidden = true
 
 function key_help() {
     var help = {
@@ -1038,13 +1039,13 @@ function key_help() {
         R: "Refresh all replicas",
         s: "Run sync on visible replicas",
         S: "Run sync on all replicas"
-    };
+    }
 
     return m("#help", { class: isHelpHidden ? "hide" : "nohide" }, 
         Object.keys(help).map(function (key) {
-            return m("div", m("b", m.trust(key)), " - ", help[key]);
+            return m("div", m("b", m.trust(key)), " - ", help[key])
         })
-    );
+    )
 }
 
 function body() {
@@ -1052,13 +1053,13 @@ function body() {
         m("#header", [
             m("h1", m.trust("&#9774;"), " craigslist blob console"),
             m("a.clickable", {
-                onclick: function() { isHelpHidden = !isHelpHidden; },
+                onclick: function() { isHelpHidden = !isHelpHidden },
             }, [
                 m("b", "shortcuts")
             ]),
             " - ",
             m("a.clickable", {
-                onclick: function() { isByIPHidden = !isByIPHidden; },
+                onclick: function() { isByIPHidden = !isByIPHidden },
             }, [
                 m("b", "by ip")
             ])
@@ -1068,13 +1069,13 @@ function body() {
         m("#summary", generate_summary_div()),
         m("#by_ip", { class: isByIPHidden ? "hide" : "" }, iterate_sorted_object(allReplicasByIP, combine_ips)),
         m("#main", main())
-    ]);
+    ])
 }
 
 function start() {
-   document.onkeypress = handle_keypress;
-   m.mount(document.body, {view: body});
-   get_config(); 
+   document.onkeypress = handle_keypress
+   m.mount(document.body, {view: body})
+   get_config()
 }
         </script>
     </head>

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -154,10 +154,10 @@ div.updating {
 }
 
         </style>
-        <script src="_jquery.js"></script>
+        // TODO: IMPORTANT For production use, mithril.js should be a local file like jQuery was
         <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
-/* global m, $ */
+/* global m */
 "use strict";
 
 function get_config() {
@@ -282,7 +282,6 @@ function update_config(data) {
         }
     }
 
-    $(document).keypress(handle_keypress);
     refresh();
 }
 
@@ -399,8 +398,12 @@ function foreach_replica(callback, filter) {
 }
 
 function handle_keypress(event) {
-    // TODO: Remove this when full Mithril changeover
+
+    // This redraw is needed because this event handler is setup outside of Mithril
+    // There are a some key presses that don't require an redraw, 
+    // but it is cleaer to just always do a redraw for now unless there is a performance issue
     setTimeout(m.redraw, 0);
+
     if (event.ctrlKey)
         return;
     if (event.which === 104) {
@@ -438,7 +441,13 @@ function handle_keypress(event) {
 
     if (url !== null) {
         foreach_replica(function (replica) {
-            $.ajax({url: url + replica, type: "GET", timeout: replica_timeout, success: m.redraw, error: m.redraw});
+            m.request({
+                url: url + replica, 
+                method: "GET",
+                config: function(xhr) { xhr.timeout = replica_timeout; },
+                // Don't try to convert the result to JSON
+                deserialize: function(value) { return value; }
+            });
         }, filter);
     }
     else
@@ -452,13 +461,13 @@ function flush_status() {
             break;
         running_status++;
         updateStateForReplica(replica, {updating: true});
-        $.ajax({
+        m.request({
             url: '/_status/' + replica,
-            type: "GET",
-            dataType: "json",
-            timeout: replica_timeout,
-            success: update_status(replica),
-            error: update_status_fail(replica)});
+            method: "GET",
+            config: function(xhr) { xhr.timeout = replica_timeout; }
+        })
+        .then(update_status(replica))
+        .catch(update_status_fail(replica));
     }
 }
 
@@ -474,8 +483,14 @@ function refresh(filter) {
         filter);
     flush_status();
     if (!filter) {
-        refresh_timer = window.setTimeout(function () { refresh(); },
-            refresh_auto_ms);
+        refresh_timer = window.setTimeout(
+            function () {
+                refresh();
+                // timeouts need to call m.redraw if they could affect drawable state
+                m.redraw();
+            },
+            refresh_auto_ms
+        );
     }
 }
 
@@ -612,9 +627,6 @@ function update_status(replica) {
         update_summary();
 
         update_replica_usage(status.cluster, status.bucket);
-
-        // TODO: Remove this when full Mithril changeover
-        setTimeout(m.redraw, 0);
     }
 }
 
@@ -867,8 +879,6 @@ function update_status_fail(replica) {
             maximumWarningSeverity: "critical", 
             updating: false
         });
-        // TODO: Remove this when full Mithril changeover
-        setTimeout(m.redraw, 0);
     }
 }
 
@@ -888,7 +898,13 @@ function button(name, url, background) {
     if (background) {
         return m(".button", {
             onclick: function() {
-                $.ajax({url: url, type: 'GET', timeout: replica_timeout, success: m.redraw, error: m.redraw});
+                m.request({
+                    url: url,
+                    method: "GET",
+                    config: function(xhr) { xhr.timeout = replica_timeout; },
+                    // Don't try to convert the result to JSON
+                    deserialize: function(value) { return value; }
+                });
             }
         }, m("b", name));
     }
@@ -1044,6 +1060,7 @@ function body() {
 }
 
 function start() {
+   document.onkeypress = handle_keypress;
    m.mount(document.body, {view: body});
    get_config(); 
 }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -472,7 +472,14 @@ function flush_status() {
         m.request({
             url: "/_status/" + replica,
             method: "GET",
-            config: configXHRTimeout
+            config: configXHRTimeout,
+            extract: function(xhr) {
+                // If there is an error, return xhr with its statusText instead of the parsed JSON result
+                if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {
+                    return JSON.parse(xhr.responseText);
+                }
+                return xhr;
+            }
         })
         .then(update_status(replica))
         .catch(update_status_fail(replica))

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -157,7 +157,9 @@ div.updating {
         <!-- TODO: IMPORTANT For production use, mithril.js should be a local file like jQuery was -->
         <script src="//unpkg.com/mithril/mithril.js"></script>
         <script>
-/* global m */
+/* global m, window, document, location, setTimeout */
+/* jshint sub: true */
+/* jshint -W097 */
 "use strict";
 
 function get_config() {
@@ -401,7 +403,7 @@ function handle_keypress(event) {
 
     // This redraw is needed because this event handler is setup outside of Mithril
     // There are a some key presses that don"t require an redraw, 
-    // but it is cleaer to just always do a redraw for now unless there is a performance issue
+    // but it is clearer to just always do a redraw for now unless there is a performance issue
     setTimeout(m.redraw, 0);
 
     if (event.ctrlKey)
@@ -691,7 +693,7 @@ function generate_replica_status_success_div(replica) {
         ("store_disk" in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
     ];
 
-    // TODO: Improve so do not habe to store value of global replica_status which may have changed
+    // TODO: Improve so do not have to store value of global replica_status which may have changed
     updateStateForReplica(replica, {maximumWarningSeverity: replica_status});
     return result;
 }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -161,7 +161,7 @@ div.updating {
 "use strict";
 
 function get_config() {
-    m.request({url: '/_config'}).then(update_config);
+    m.request({url: "/_config"}).then(update_config);
 }
 
 var config;
@@ -300,7 +300,7 @@ function grid() {
                                 return hover_help(
                                     m("a", 
                                         {
-                                            href: "#bucket_" + clusterIndex + '_' + bucketIndex,
+                                            href: "#bucket_" + clusterIndex + "_" + bucketIndex,
                                             onclick: function() {
                                                 updateStateForBucketReplicas(bucket, {hidden: false});
                                             }
@@ -326,7 +326,7 @@ function main() {
                 )
             ),
             cluster.map(function (bucket, bucketIndex) {
-                return m(".bucket#bucket_" + clusterIndex + '_' + bucketIndex,
+                return m(".bucket#bucket_" + clusterIndex + "_" + bucketIndex,
                     m(".group.clickable", 
                         {
                             onclick: function(event) {
@@ -336,7 +336,7 @@ function main() {
                         m(".name",
                             m("b", "bucket " + bucketIndex)
                         ),
-                        metric('write weight', bucket.write_weight, 0, 0, null, 0),
+                        metric("write weight", bucket.write_weight, 0, 0, null, 0),
                         bucket.replicas.map(function (replica, replicaIndex) {
                             return getReplicaLabel(replica, "metric");
                         })
@@ -400,7 +400,7 @@ function foreach_replica(callback, filter) {
 function handle_keypress(event) {
 
     // This redraw is needed because this event handler is setup outside of Mithril
-    // There are a some key presses that don't require an redraw, 
+    // There are a some key presses that don"t require an redraw, 
     // but it is cleaer to just always do a redraw for now unless there is a performance issue
     setTimeout(m.redraw, 0);
 
@@ -424,11 +424,11 @@ function handle_keypress(event) {
     if (upper_key === 82 || event.which === 32)
         url = null;
     if (upper_key === 66)
-        url = '/_buffer/';
+        url = "/_buffer/";
     if (upper_key === 80)
-        url = '/_purge/';
+        url = "/_purge/";
     if (upper_key === 83)
-        url = '/_sync/';
+        url = "/_sync/";
     if (url === undefined)
         return;
 
@@ -466,7 +466,7 @@ function flush_status() {
         running_status++;
         updateStateForReplica(replica, {updating: true});
         m.request({
-            url: '/_status/' + replica,
+            url: "/_status/" + replica,
             method: "GET",
             config: configXHRTimeout
         })
@@ -499,33 +499,33 @@ function refresh(filter) {
 }
 
 var summary = {
-    'cluster events': {
-        'critical': 10000,
-        'factor': 1000,
-        'type': 'metric',
-        'values': {},
-        'warning': 1000,
-        'help_text': 'The total number of events queued to a cluster across all replicas.'
+    "cluster events": {
+        critical: 10000,
+        factor: 1000,
+        type: "metric",
+        values: {},
+        warning: 1000,
+        help_text: "The total number of events queued to a cluster across all replicas."
     },
-    'disk inodes': {
-        'factor': 1000,
-        'type': 'usage',
-        'values': {},
-        'help_text': 'The &lt;used&gt;/&lt;total&gt; number of disk inodes across all replicas.'
+    "disk inodes": {
+        factor: 1000,
+        type: "usage",
+        values: {},
+        help_text: "The &lt;used&gt;/&lt;total&gt; number of disk inodes across all replicas."
     },
-    'disk space': {
-        'factor': 1024,
-        'type': 'usage',
-        'values': {},
-        'help_text': 'The &lt;used&gt;/&lt;total&gt; amount of disk space across all replicas.'
+    "disk space": {
+        factor: 1024,
+        type: "usage",
+        values: {},
+        help_text: "The &lt;used&gt;/&lt;total&gt; amount of disk space across all replicas."
     },
-    'replica events': {
-        'critical': 10000,
-        'factor': 1000,
-        'type': 'metric',
-        'values': {},
-        'warning': 1000,
-        'help_text': 'The total number of events queued to a replica across all replicas.'
+    "replica events": {
+        critical: 10000,
+        factor: 1000,
+        type: "metric",
+        values: {},
+        warning: 1000,
+        help_text: "The total number of events queued to a replica across all replicas."
     }
 };
 
@@ -544,14 +544,14 @@ function update_summary_metrics(name, details) {
     var usage = 0;
     var total = 0;
     var count = 0;
-    for (var replica in details['values']) {
+    for (var replica in details["values"]) {
         count++;
-        if (details['type'] === 'usage') {
-            usage += details['values'][replica][0];
-            total += details['values'][replica][1];
+        if (details["type"] === "usage") {
+            usage += details["values"][replica][0];
+            total += details["values"][replica][1];
         }
         else
-            total += details['values'][replica];
+            total += details["values"][replica];
     }
     // Add storage object into summary data structure for later use when generating summary metrics divs
     details._replicaStats = {
@@ -563,15 +563,15 @@ function update_summary_metrics(name, details) {
 
 function summary_metrics(name, details) {
     if (!details._replicaStats || details._replicaStats.count === 0)
-        return '';
-    if (details['type'] === 'usage')
+        return "";
+    if (details["type"] === "usage")
         return hover_help(
-            usage_metric(name, details._replicaStats.total, details._replicaStats.usage, 60, 80, details['factor']),
-            details['help_text']
+            usage_metric(name, details._replicaStats.total, details._replicaStats.usage, 60, 80, details["factor"]),
+            details["help_text"]
         );
     return hover_help(
-        metric(name, details._replicaStats.total, details['warning'], details['critical'], details['factor']),
-        details['help_text']
+        metric(name, details._replicaStats.total, details["warning"], details["critical"], details["factor"]),
+        details["help_text"]
     );
 }
 
@@ -620,13 +620,13 @@ function update_status(replica) {
             updating: false
         });
 
-        summary['replica events']['values'][replica] = 0;
+        summary["replica events"]["values"][replica] = 0;
         iterate_sorted_object(status.replicas, update_replica_metrics(replica));
 
-        summary['cluster events']['values'][replica] = 0;
+        summary["cluster events"]["values"][replica] = 0;
         iterate_sorted_object(status.clusters, update_cluster_metrics(replica));
         
-        if ('store_disk' in status) update_store_disk_metrics(replica, status.store_disk);
+        if ("store_disk" in status) update_store_disk_metrics(replica, status.store_disk);
 
         update_summary();
 
@@ -641,36 +641,36 @@ function update_status(replica) {
 
 function generate_replica_status_success_div(replica) {
     // TODO: This replica_status global is updated as a side effect of generating displays for metrics
-    replica_status = 'ok';
-    var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
+    replica_status = "ok";
+    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port;
     var status = getStateForReplica(replica).status;
-    var sync_status_severity = (status.sync_status || "").indexOf('failed') === 0 ? 1 : 0;
-    var purge_status_severity = (status.purge_status || "").indexOf('failed') === 0 ? 1 : 0;
-    var buffer_status_severity = (status.buffer_status || "").indexOf('failed') === 0 ? 1 : 0;
+    var sync_status_severity = (status.sync_status || "").indexOf("failed") === 0 ? 1 : 0;
+    var purge_status_severity = (status.purge_status || "").indexOf("failed") === 0 ? 1 : 0;
+    var buffer_status_severity = (status.buffer_status || "").indexOf("failed") === 0 ? 1 : 0;
     var result = [
         m(".group",
             getReplicaLabel(replica, "name"),
-            button(address, 'http://' + address + '/_console'),
+            button(address, "http://" + address + "/_console"),
             m(".button", {
                 onclick: refresh.bind(null, replica)
             }, m("b", "refresh"))
         ),
         m(".group",
-            button('sync', '/_sync/' + replica, true),
+            button("sync", "/_sync/" + replica, true),
             hover_help(
-                metric('sync status', status.sync_status, 0, 0, null, sync_status_severity),
+                metric("sync status", status.sync_status, 0, 0, null, sync_status_severity),
                 sync_status_help(status.sync_status)
             ),
 
-            button('purge', '/_purge/' + replica, true),
+            button("purge", "/_purge/" + replica, true),
             hover_help(
-                metric('purge status', status.purge_status, 0, 0, null, purge_status_severity),
+                metric("purge status", status.purge_status, 0, 0, null, purge_status_severity),
                 purge_status_help(status.purge_status)
             ),
 
-            button('buffer', '/_buffer/' + replica, true),
+            button("buffer", "/_buffer/" + replica, true),
             hover_help(
-                metric('buffer status', status.buffer_status, 0, 0, null, buffer_status_severity),
+                metric("buffer status", status.buffer_status, 0, 0, null, buffer_status_severity),
                 buffer_status_help(status.buffer_status)
             )
         ),
@@ -683,12 +683,12 @@ function generate_replica_status_success_div(replica) {
         m(".group",
             hover_help(
                 iterate_sorted_object(status.events, event_metrics),
-                'The &lt;current&gt;/&lt;max&gt;/&lt;total&gt; number of events this replica has created.'
+                "The &lt;current&gt;/&lt;max&gt;/&lt;total&gt; number of events this replica has created."
             )
         ),
 
-        ('index_sqlite' in status) ? m(".group", index_sqlite_metrics(replica, status.index_sqlite)) : [],
-        ('store_disk' in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
+        ("index_sqlite" in status) ? m(".group", index_sqlite_metrics(replica, status.index_sqlite)) : [],
+        ("store_disk" in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
     ];
 
     // TODO: Improve so do not habe to store value of global replica_status which may have changed
@@ -698,131 +698,131 @@ function generate_replica_status_success_div(replica) {
 
 function sync_status_help(status) {
     var help;
-    if (status.indexOf('start delay') === 0)
-        return 'Sync has not been run since server start.';
-    if (status.indexOf('failed') === 0)
-        return 'Sync failed to complete.';
-    if (status.indexOf('local checksums') === 0)
-        help = 'Sync is running and is currently computing a list of ' +
-            'checksums for this replica.';
-    else if (status.indexOf('source checksums') === 0)
-        help = 'Sync is running and is currently computing a list of ' +
-            'checksums for a peer replica.';
-    else if (status.indexOf('diff checksums') === 0)
-        help = 'Sync is running and is currently comparing a list of ' +
-            'checksums between this replica and a peer replica.';
-    else if (status.indexOf('local blobs') === 0)
-        help = 'Sync is running and is currently getting a list of blobs ' +
-            'for this replica.';
-    else if (status.indexOf('source blobs') === 0)
-        help = 'Sync is running and is currently getting a list of blobs ' +
-            'for a peer replica.';
-    else if (status.indexOf('diff blobs') === 0)
-        help = 'Sync is running and is currently comparing a list of blobs ' +
-            'between this replica and a peer replica.';
-    else if (status.indexOf('put') === 0)
-        help = 'Sync is running and is currently grabbing a blob from a ' +
-            'peer to put into this replica.';
-    else if (status.indexOf('delete') === 0)
-        help = 'Sync is running and is currently updating the delete time ' +
-            'for a blob in this replica.';
-    else if (status.indexOf('synced') === 0)
-        help = 'Sync is done running.';
+    if (status.indexOf("start delay") === 0)
+        return "Sync has not been run since server start.";
+    if (status.indexOf("failed") === 0)
+        return "Sync failed to complete.";
+    if (status.indexOf("local checksums") === 0)
+        help = "Sync is running and is currently computing a list of " +
+            "checksums for this replica.";
+    else if (status.indexOf("source checksums") === 0)
+        help = "Sync is running and is currently computing a list of " +
+            "checksums for a peer replica.";
+    else if (status.indexOf("diff checksums") === 0)
+        help = "Sync is running and is currently comparing a list of " +
+            "checksums between this replica and a peer replica.";
+    else if (status.indexOf("local blobs") === 0)
+        help = "Sync is running and is currently getting a list of blobs " +
+            "for this replica.";
+    else if (status.indexOf("source blobs") === 0)
+        help = "Sync is running and is currently getting a list of blobs " +
+            "for a peer replica.";
+    else if (status.indexOf("diff blobs") === 0)
+        help = "Sync is running and is currently comparing a list of blobs " +
+            "between this replica and a peer replica.";
+    else if (status.indexOf("put") === 0)
+        help = "Sync is running and is currently grabbing a blob from a " +
+            "peer to put into this replica.";
+    else if (status.indexOf("delete") === 0)
+        help = "Sync is running and is currently updating the delete time " +
+            "for a blob in this replica.";
+    else if (status.indexOf("synced") === 0)
+        help = "Sync is done running.";
     else
-        help = 'Status of current/last sync operation.';
-    return help + ' The counts are the number of blobs skipped, put, ' +
-        'deleted, or failed for each peer.';
+        help = "Status of current/last sync operation.";
+    return help + " The counts are the number of blobs skipped, put, " +
+        "deleted, or failed for each peer.";
 }
 
 function purge_status_help(status) {
     var help;
-    if (status.indexOf('start delay') === 0)
-        return 'Purge has not been run since server start.';
-    if (status.indexOf('failed') === 0)
-        return 'Purge failed to complete.';
-    if (status.indexOf('get_expired') === 0)
-        help = 'Purge is running and is currently getting a list of expired ' +
-            'blobs from the index.';
-    else if (status.indexOf('delete') === 0)
-        help = 'Purge is running and is currently deleting an expired blob ' +
-            'from disk.';
-    else if (status.indexOf('delete_expired') === 0)
-        help = 'Purge is running and is currently deleting expired blobs ' +
-            'from the index.';
-    else if (status.indexOf('purged') === 0)
-        help = 'Purge is done running.';
+    if (status.indexOf("start delay") === 0)
+        return "Purge has not been run since server start.";
+    if (status.indexOf("failed") === 0)
+        return "Purge failed to complete.";
+    if (status.indexOf("get_expired") === 0)
+        help = "Purge is running and is currently getting a list of expired " +
+            "blobs from the index.";
+    else if (status.indexOf("delete") === 0)
+        help = "Purge is running and is currently deleting an expired blob " +
+            "from disk.";
+    else if (status.indexOf("delete_expired") === 0)
+        help = "Purge is running and is currently deleting expired blobs " +
+            "from the index.";
+    else if (status.indexOf("purged") === 0)
+        help = "Purge is done running.";
     else
-        help = 'Status of current/last purge operation.';
-    return help + ' The count is the number of blobs that were purged ' +
-            'during this run.';
+        help = "Status of current/last purge operation.";
+    return help + " The count is the number of blobs that were purged " +
+            "during this run.";
 }
 
 function buffer_status_help(status) {
     var help;
-    if (status.indexOf('start delay') === 0)
-        return 'Buffer has not been run since server start.';
-    if (status.indexOf('failed') === 0)
-        help = 'Buffer failed to complete.';
-    if (status.indexOf('get_replica_events') === 0)
-        help = 'Buffer is running and is currently getting a list of ' +
-            'replica events from the index to buffer into memory.';
-    else if (status.indexOf('get_cluster_events') === 0)
-        help = 'Buffer is running and is currently getting a list of ' +
-            'cluster events from the index to buffer into memory.';
-    else if (status.indexOf('buffered') === 0)
-        help = 'Buffer is done running.';
+    if (status.indexOf("start delay") === 0)
+        return "Buffer has not been run since server start.";
+    if (status.indexOf("failed") === 0)
+        help = "Buffer failed to complete.";
+    if (status.indexOf("get_replica_events") === 0)
+        help = "Buffer is running and is currently getting a list of " +
+            "replica events from the index to buffer into memory.";
+    else if (status.indexOf("get_cluster_events") === 0)
+        help = "Buffer is running and is currently getting a list of " +
+            "cluster events from the index to buffer into memory.";
+    else if (status.indexOf("buffered") === 0)
+        help = "Buffer is done running.";
     else
-        help = 'Status of current/last buffer operation.';
-    return help + ' The counts are the number of replica/cluster events ' +
-            'that could be buffered during this run.';
+        help = "Status of current/last buffer operation.";
+    return help + " The counts are the number of replica/cluster events " +
+            "that could be buffered during this run.";
 }
 
 function index_sqlite_metrics(replica, status) {
     return [
-        metric('sqlite database', status.database),
+        metric("sqlite database", status.database),
         hover_help(
-            usage_metric('sqlite size', status.max_size, status.size, 60, 80, 1024),
-            'The &lt;used&gt;/&lt;total&gt; amount of disk space for the index.'
+            usage_metric("sqlite size", status.max_size, status.size, 60, 80, 1024),
+            "The &lt;used&gt;/&lt;total&gt; amount of disk space for the index."
         ),
         hover_help(
-            metric('sqlite queue size', status.queue_size, 10, 20),
-            'The number of events in the index thread queue.'
+            metric("sqlite queue size", status.queue_size, 10, 20),
+            "The number of events in the index thread queue."
         )
     ];
 }
 
 function update_store_disk_metrics(replica, status) {
-    summary['disk space']['values'][status.device_id] = 
+    summary["disk space"]["values"][status.device_id] = 
         [status.total_space - status.free_space, status.total_space];
-    summary['disk inodes']['values'][status.device_id] = 
+    summary["disk inodes"]["values"][status.device_id] = 
         [status.total_inodes - status.free_inodes, status.total_inodes];
     replica_usage[replica] = status.total_inodes - status.free_inodes;
 }
 
 function store_disk_metrics(replica, status) {
     return [
-        metric('disk path', status.path),
+        metric("disk path", status.path),
         hover_help(
-            usage_metric('disk space', status.total_space,
+            usage_metric("disk space", status.total_space,
                 status.total_space - status.free_space, 60, 80, 1024),
-            'The &lt;used&gt;/&lt;total&gt; amount of disk space.'
+            "The &lt;used&gt;/&lt;total&gt; amount of disk space."
         ),
         hover_help(
-            usage_metric('disk inodes', status.total_inodes,
+            usage_metric("disk inodes", status.total_inodes,
                 status.total_inodes - status.free_inodes, 60, 80, 1000),
-            'The &lt;used&gt;/&lt;total&gt; number of disk inodes.'
+            "The &lt;used&gt;/&lt;total&gt; number of disk inodes."
         ),
         hover_help(
-            metric('disk queue size', status.queue_size, 10, 20),
-            'The number of events in the disk thread queue.'
+            metric("disk queue size", status.queue_size, 10, 20),
+            "The number of events in the disk thread queue."
         )
     ];
 }
 
 function update_replica_metrics(summary_replica) {
     return function (replica, status) {
-        if ('events' in status) {
-            summary['replica events']['values'][summary_replica] += status.events;
+        if ("events" in status) {
+            summary["replica events"]["values"][summary_replica] += status.events;
         }
     };
 }
@@ -831,19 +831,19 @@ function replica_metrics(summary_replica) {
     return function (replica, status) {
         var replica_retry = config.clblob.client.replica_retry;
         return [
-            ('events' in status) ?
+            ("events" in status) ?
                 hover_help(
-                    metric(replica + ' events',
-                        status.buffer_events + '/' + status.events,
+                    metric(replica + " events",
+                        status.buffer_events + "/" + status.events,
                         config.clblob.client.replica_event_buffer_size,
                         config.clblob.client.replica_event_buffer_size * 10,
                         1000, status.events),
-                    'The number of &lt;buffered&gt;/&lt;total&gt; events queued ' +
-                        'up to go to replica ' + replica + '.'
+                    "The number of &lt;buffered&gt;/&lt;total&gt; events queued " +
+                        "up to go to replica " + replica + "."
                     ) :
                 [],
-            ('last_failed' in status && status.last_failed < replica_retry) ?
-                metric(replica + ' failed', status.last_failed, replica_retry, 0, null) :
+            ("last_failed" in status && status.last_failed < replica_retry) ?
+                metric(replica + " failed", status.last_failed, replica_retry, 0, null) :
                 []
         ];
     };
@@ -851,31 +851,31 @@ function replica_metrics(summary_replica) {
 
 function update_cluster_metrics(replica) {
     return function (cluster, status) {
-        if ('events' in status) {
-            summary['cluster events']['values'][replica] += status.events;
+        if ("events" in status) {
+            summary["cluster events"]["values"][replica] += status.events;
         }
     };
 }
 
 function cluster_metrics(replica) {
     return function (cluster, status) {
-        if ('events' in status) {
+        if ("events" in status) {
             return hover_help(
-                metric('cluster ' + cluster + ' events',
-                    status.buffer_events + '/' + status.events,
+                metric("cluster " + cluster + " events",
+                    status.buffer_events + "/" + status.events,
                     config.clblob.client.cluster_event_buffer_size,
                     config.clblob.client.cluster_event_buffer_size * 10,
                     1000, status.events),
-                'The number of &lt;buffered&gt;/&lt;total&gt; events queued ' +
-                    'up to go to cluster ' + cluster + '.');
+                "The number of &lt;buffered&gt;/&lt;total&gt; events queued " +
+                    "up to go to cluster " + cluster + ".");
         }
         return [];
     };
 }
 
 function event_metrics(event, status) {
-    return metric(event + ' events',
-        status.current + '/' + status.max + '/' + si_prefix(status.total), 250,
+    return metric(event + " events",
+        status.current + "/" + status.max + "/" + si_prefix(status.total), 250,
         500, 1000, status.current);
 }
 
@@ -893,13 +893,13 @@ function update_status_fail(replica) {
 }
 
 function generate_replica_status_fail_div(replica) {
-    var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
+    var address = allReplicasByName[replica].ip + ":" + allReplicasByName[replica].port;
     var status = getStateForReplica(replica).status;
 
     return m(".group",
         getReplicaLabel(replica, "name"),
-        button(address, 'http://' + address + '/_console'),
-        metric('failed', status.statusText, 0, 0, null, 1)
+        button(address, "http://" + address + "/_console"),
+        metric("failed", status.statusText, 0, 0, null, 1)
     );
 }
 
@@ -929,14 +929,14 @@ function metric(name, value, warning, critical, factor, notify_value) {
     if (notify_value === undefined)
         notify_value = value;
     var notify = get_notify_class(notify_value, warning, critical);
-    return m(".metric." + notify, m("b", name + ":"), si_prefix(value, factor));
+    return m(".metric." + notify, m("b", name + ":"), " ", si_prefix(value, factor));
 }
 
 function usage_metric(name, total, used, warning, critical, factor) {
     var used_percent = Math.round((used / total) * 100);
     return metric(
         name, 
-        si_prefix(used, factor) + '/' + si_prefix(total, factor) + ' (' + used_percent + '%)', 
+        si_prefix(used, factor) + "/" + si_prefix(total, factor) + " (" + used_percent + "%)", 
         warning,
         critical,
         null,
@@ -967,31 +967,31 @@ function iterate_sorted_object(key_values, callback) {
 function get_notify_class(value, warning, critical) {
     if (warning > critical) {
         if (value < critical) {
-            replica_status = 'critical';
-            return 'critical';
+            replica_status = "critical";
+            return "critical";
         }
         else if (value < warning) {
-            if (replica_status !== 'critical')
-                replica_status = 'warning';
-            return 'warning';
+            if (replica_status !== "critical")
+                replica_status = "warning";
+            return "warning";
         }
     }
     else {
         if (value > critical) {
-            replica_status = 'critical';
-            return 'critical';
+            replica_status = "critical";
+            return "critical";
         }
         else if (value > warning) {
-            if (replica_status !== 'critical')
-                replica_status = 'warning';
-            return 'warning';
+            if (replica_status !== "critical")
+                replica_status = "warning";
+            return "warning";
         }
     }
-    return 'normal';
+    return "normal";
 }
 
-var SI_PREFIXES_LARGE = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-var SI_PREFIXES_SMALL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y'];
+var SI_PREFIXES_LARGE = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"];
+var SI_PREFIXES_SMALL = ["", "m", "u", "n", "p", "f", "a", "z", "y"];
 
 function si_prefix(value, factor) {
     if (factor === null)

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -181,6 +181,7 @@ var replica_timeout = 2000
 var clusters = []
 var allReplicasByName = {}
 var allReplicasByIP = {}
+var summaryAvailable = false;
 
 // stateForReplica stores the last known state for a replica
 // its contents are: 
@@ -533,10 +534,12 @@ var summary = {
 }
 
 function update_summary() {
+    summaryAvailable = true;
     iterate_sorted_object(summary, update_summary_metrics)
 }
 
 function generate_summary_div() {
+    if (!summaryAvailable) return [];
     return m(".group",
         m(".name", m("b", "summary")),
         iterate_sorted_object(summary, summary_metrics)

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -176,27 +176,30 @@ var replica_usage = {};
 var replica_timeout = 2000;
 
 var clusters = [];
-var by_ip = {};
+var allReplicasByName = {};
+var allReplicasByIP = {};
 
 function update_config(data) {
     config = data;
     clusters = config.clblob.client.clusters;
+    allReplicasByName = config.clblob.client.replicas;
     
-    for (var cluster = 0; cluster < clusters.length; cluster++) {
-        var buckets = clusters[cluster];
-        for (var bucket = 0; bucket < buckets.length; bucket++) {
-            var replicas = buckets[bucket].replicas;
-            for (var replica = 0; replica < replicas.length; replica++) {
-                var ip = config.clblob.client.replicas[replicas[replica]].ip;
-                var port = config.clblob.client.replicas[replicas[replica]].port;
-                if (!by_ip[ip]) by_ip[ip] = {};
-                by_ip[ip][port] = replicas[replica];
-                refresh_replicas.push(replicas[replica]);
+    for (var clusterIndex = 0; clusterIndex < clusters.length; clusterIndex++) {
+        var buckets = clusters[clusterIndex];
+        for (var bucketIndex = 0; bucketIndex < buckets.length; bucketIndex++) {
+            var replicasInBucket = buckets[bucketIndex].replicas;
+            for (var replicaIndex = 0; replicaIndex < replicasInBucket.length; replicaIndex++) {
+                var replica = replicasInBucket[replicaIndex];
+                var ip = allReplicasByName[replica].ip;
+                var port = allReplicasByName[replica].port;
+                if (!allReplicasByIP[ip]) allReplicasByIP[ip] = {};
+                allReplicasByIP[ip][port] = replica;
+                refresh_replicas.push(replica);
             }
         }
     }
 
-    $('#by_ip').html(iterate_sorted_object(by_ip, combine_ips));
+    $('#by_ip').html(iterate_sorted_object(allReplicasByIP, combine_ips));
 
     $(document).keypress(handle_keypress);
     refresh();
@@ -454,7 +457,7 @@ function summary_metrics(name, details) {
 
 function update_replica_usage(cluster, bucket) {
     var replica;
-    var replicas = config.clblob.client.clusters[cluster][bucket].replicas;
+    var replicas = clusters[cluster][bucket].replicas;
     var max_usage = 0;
     for (replica = 0; replica < replicas.length; replica++) {
         if (max_usage < replica_usage[replicas[replica]])
@@ -485,8 +488,7 @@ function update_status(replica) {
         running_status--;
         replica_status = 'ok';
         var html = '';
-        var address = config.clblob.client.replicas[replica].ip + ':' +
-            config.clblob.client.replicas[replica].port;
+        var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
         html += '<div class="group">';
         html += '<div class="name replica_name_' + replica + '"><b>' +
             replica + '</b></div>';
@@ -724,8 +726,7 @@ function update_status_fail(replica) {
         flush_status();
         running_status--;
         var html = '';
-        var address = config.clblob.client.replicas[replica].ip + ':' +
-            config.clblob.client.replicas[replica].port;
+        var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
         html += '<div class="group">' +
             '<div class="name replica_name_' + replica + '"><b>' + replica +
             '</b></div>' +

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -179,6 +179,89 @@ var clusters = [];
 var allReplicasByName = {};
 var allReplicasByIP = {};
 
+// stateForReplica stores the last known state for a replica
+// its contents are: 
+// replica_ID: {
+//    requestResult: "success" | "error" | null, 
+//    status: Object, 
+//    hidden: boolean, 
+//    maximumWarningSeverity: "ok" | "warning" | "critical", 
+//    updating: boolean,
+//    relativeUsagePercent: number
+//}
+var stateForReplica = {};
+
+function getStateForReplica(replica) {
+    var state = stateForReplica[replica];
+    if (!state) {
+        state = {
+            requestResult: null, 
+            status: {}, 
+            hidden: true,
+            maximumWarningSeverity: "ok",
+            updating: false,
+            relativeUsagePercent: null
+        };
+        stateForReplica[replica] = state;
+    }
+    return state;
+}
+
+// Will only change keys supplied in newState and leave others as they were
+function updateStateForReplica(replica, newState) {
+    var state = getStateForReplica(replica);
+    for (var key in newState) {
+        state[key] = newState[key];
+    }
+}
+
+function updateStateForAllReplicas(newState) {
+    for (let replica in stateForReplica) {
+        var state = getStateForReplica(replica);
+        for (var key in newState) {
+            state[key] = newState[key];
+        }
+    }
+}
+
+function updateStateForBucketReplicas(bucket, newState) {
+    bucket.replicas.map(function (replica) {
+        var state = getStateForReplica(replica);
+        for (var key in newState) {
+            state[key] = newState[key];
+        }
+    });
+}
+
+function getStateForBucketReplicas(bucket) {
+    var result = [];
+    bucket.replicas.map(function (replica) {
+        var state = getStateForReplica(replica);
+        result.push(state);
+    });
+    return result;
+}
+
+function getReplicaLabelCSSClasses(replica) {
+    var state = getStateForReplica(replica);
+    var severity = "." + state.maximumWarningSeverity;
+    var updating = state.updating ? ".updating" : ""
+    return severity + updating;
+}
+
+// type is name or metric
+// Label generated may include relative usage percent if available.
+// Label will also include warning classes if needed.
+function getReplicaLabel(replica, type) {
+    var relativeUsagePercent = getStateForReplica(replica).relativeUsagePercent;
+    var relativeUsagePercentText = relativeUsagePercent === null ? "" : " " + relativeUsagePercent + "%";
+    var possibleColonForRelativeUsagePercent = relativeUsagePercent === null ? "" : ":";
+    return m("." + type + ".replica_name_" + replica + getReplicaLabelCSSClasses(replica), 
+        m("b", replica, possibleColonForRelativeUsagePercent),
+        relativeUsagePercentText
+    )
+}
+
 function update_config(data) {
     config = data;
     clusters = config.clblob.client.clusters;
@@ -199,8 +282,6 @@ function update_config(data) {
         }
     }
 
-    $('#by_ip').html(iterate_sorted_object(allReplicasByIP, combine_ips));
-
     $(document).keypress(handle_keypress);
     refresh();
 }
@@ -217,16 +298,15 @@ function grid() {
                         return m(".grid_bucket", 
                             m(".grid_bucket_number", bucketIndex),
                             bucket.replicas.map(function (replica, replicaIndex) {
-                                return m_hover_help(
+                                return hover_help(
                                     m("a", 
                                         {
                                             href: "#bucket_" + clusterIndex + '_' + bucketIndex,
                                             onclick: function() {
-                                                // TODO: Store open/close state in domain not DOM
-                                                $('#replica_' + replica).parent().children('div.replica').removeClass('hide');
+                                                updateStateForBucketReplicas(bucket, {hidden: false});
                                             }
                                         }, 
-                                        m(".grid_replica#grid_replica_" + replica)
+                                        m(".grid_replica#grid_replica_" + replica + getReplicaLabelCSSClasses(replica))
                                     ),
                                     replica
                                 )
@@ -251,19 +331,15 @@ function main() {
                     m(".group.clickable", 
                         {
                             onclick: function(event) {
-                                // TODO: store this state in domain not DOM
-                                $(this).siblings('div.replica').toggleClass('hide');
+                                updateStateForBucketReplicas(bucket, {hidden: !getStateForBucketReplicas(bucket)[0].hidden});
                             }
                         }, 
                         m(".name",
                             m("b", "bucket " + bucketIndex)
                         ),
-                        // TODO: Remove this use of m.trust
-                        m.trust(metric('write weight', bucket.write_weight, 0, 0, null, 0)),
+                        metric('write weight', bucket.write_weight, 0, 0, null, 0),
                         bucket.replicas.map(function (replica, replicaIndex) {
-                            return m(".metric#replica_name_" + replica,
-                                m("b", replica)
-                            )
+                            return getReplicaLabel(replica, "metric");
                         })
                     ),
                     replica_main(bucket.replicas)
@@ -275,34 +351,45 @@ function main() {
 
 function replica_main(replicas) {
     return replicas.map(function (replica, replicaIndex) {
-        // TODO: Use of css class .hide here is problematical 
-        // since we're relying on vdom not putting it back while jQuery interacts with classes
-        return m(".replica.hide#replica_" + replica,
-            m(".group", 
-                m(".name#replica_name_" + replica,
-                    m("b", replica)
-                )
+        var requestResult = getStateForReplica(replica).requestResult;
+        var innerDiv;
+        if (requestResult === "success") {
+            innerDiv = generate_replica_status_success_div(replica);
+        } else if (requestResult === "error") {
+            innerDiv = generate_replica_status_fail_div(replica);
+        } else {
+            innerDiv = m(".group", 
+                getReplicaLabel(replica, "name")
             )
+        }
+
+        var state = getStateForReplica(replica);
+        var hideClass = state.hidden ? ".hide" : "";
+        var warningClass = state.requestResult === "error" ? ".warning" : "";
+        return m(".replica#replica_" + replica + hideClass + warningClass,
+            innerDiv
         )
     });
 }
 
 function combine_ips(ip, ports) {
-    return '<div class="ip"><div class="group">' + '<div class="name"><b>ip ' +
-        ip + '</b></div>' + iterate_sorted_object(ports, combine_ports) +
-        '</div></div>';
+    return m(".ip",
+        m(".group",
+            m(".name", m("b", "ip " + ip)),
+            iterate_sorted_object(ports, combine_ports)
+        )
+    )
 }
 
 function combine_ports(port, replica) {
-    return '<div class="metric replica_name_' + replica + '"><b>' + replica +
-        '</b></div>';
+    return getReplicaLabel(replica, "metric");
 }
 
 function foreach_replica(callback, filter) {
     for (var index = 0; index < refresh_replicas.length; index++) {
         var replica = refresh_replicas[index];
         if (filter === true) {
-            if ($('#replica_' + replica).hasClass('hide'))
+            if (getStateForReplica(replica).hidden)
                 continue;
         }
         else if (filter && filter !== replica)
@@ -312,18 +399,20 @@ function foreach_replica(callback, filter) {
 }
 
 function handle_keypress(event) {
+    // TODO: Remove this when full Mithril changeover
+    setTimeout(m.redraw, 0);
     if (event.ctrlKey)
         return;
     if (event.which === 104) {
-        $('div.replica').addClass('hide');
+        updateStateForAllReplicas({hidden: true});
         return;
     }
     if (event.which === 72) {
-        $('div.replica').removeClass('hide');
+        updateStateForAllReplicas({hidden: false});
         return;
     }
     if (event.which === 73 || event.which === 105) {
-        $('#by_ip').toggleClass('hide');
+        isByIPHidden = !isByIPHidden;
         return;
     }
     var url;
@@ -349,7 +438,7 @@ function handle_keypress(event) {
 
     if (url !== null) {
         foreach_replica(function (replica) {
-            $.ajax({url: url + replica, type: "GET", timeout: replica_timeout});
+            $.ajax({url: url + replica, type: "GET", timeout: replica_timeout, success: m.redraw, error: m.redraw});
         }, filter);
     }
     else
@@ -362,8 +451,7 @@ function flush_status() {
         if (!replica)
             break;
         running_status++;
-        $('#grid_replica_' + replica).addClass('updating');
-        $('div.replica_name_' + replica).addClass('updating');
+        updateStateForReplica(replica, {updating: true});
         $.ajax({
             url: '/_status/' + replica,
             type: "GET",
@@ -398,39 +486,42 @@ var summary = {
         'type': 'metric',
         'values': {},
         'warning': 1000,
-        'help_text': 'The total number of events queued to a cluster across ' +
-            'all replicas.'},
+        'help_text': 'The total number of events queued to a cluster across all replicas.'
+    },
     'disk inodes': {
         'factor': 1000,
         'type': 'usage',
         'values': {},
-        'help_text': 'The &lt;used&gt;/&lt;total&gt; number of disk inodes ' +
-            'across all replicas.'},
+        'help_text': 'The &lt;used&gt;/&lt;total&gt; number of disk inodes across all replicas.'
+    },
     'disk space': {
         'factor': 1024,
         'type': 'usage',
         'values': {},
-        'help_text': 'The &lt;used&gt;/&lt;total&gt; amount of disk space ' +
-            'across all replicas.'},
+        'help_text': 'The &lt;used&gt;/&lt;total&gt; amount of disk space across all replicas.'
+    },
     'replica events': {
         'critical': 10000,
         'factor': 1000,
         'type': 'metric',
         'values': {},
         'warning': 1000,
-        'help_text': 'The total number of events queued to a replica across ' +
-            'all replicas.'}};
+        'help_text': 'The total number of events queued to a replica across all replicas.'
+    }
+};
 
 function update_summary() {
-    var html = '';
-    html += '<div class="group">';
-    html += '<div class="name"><b>summary</b></div>';
-    html += iterate_sorted_object(summary, summary_metrics);
-    html += '</div>';
-    $('#summary').html(html);
+    iterate_sorted_object(summary, update_summary_metrics);
 }
 
-function summary_metrics(name, details) {
+function generate_summary_div() {
+    return m(".group",
+        m(".name", m("b", "summary")),
+        iterate_sorted_object(summary, summary_metrics)
+    );
+}
+
+function update_summary_metrics(name, details) {
     var usage = 0;
     var total = 0;
     var count = 0;
@@ -443,113 +534,144 @@ function summary_metrics(name, details) {
         else
             total += details['values'][replica];
     }
-    if (count === 0)
+    // Add storage object into summary data structure for later use when generating summary metrics divs
+    details._replicaStats = {
+        usage: usage,
+        total: total,
+        count: count
+    }
+}
+
+function summary_metrics(name, details) {
+    if (!details._replicaStats || details._replicaStats.count === 0)
         return '';
     if (details['type'] === 'usage')
         return hover_help(
-            usage_metric(name, total, usage, 60, 80, details['factor']),
-            details['help_text']);
+            usage_metric(name, details._replicaStats.total, details._replicaStats.usage, 60, 80, details['factor']),
+            details['help_text']
+        );
     return hover_help(
-        metric(name, total, details['warning'], details['critical'],
-            details['factor']),
-        details['help_text']);
+        metric(name, details._replicaStats.total, details['warning'], details['critical'], details['factor']),
+        details['help_text']
+    );
 }
 
 function update_replica_usage(cluster, bucket) {
-    var replica;
+    var replicaIndex;
     var replicas = clusters[cluster][bucket].replicas;
     var max_usage = 0;
-    for (replica = 0; replica < replicas.length; replica++) {
-        if (max_usage < replica_usage[replicas[replica]])
-            max_usage = replica_usage[replicas[replica]];
+    for (replicaIndex = 0; replicaIndex < replicas.length; replicaIndex++) {
+        if (max_usage < replica_usage[replicas[replicaIndex]])
+            max_usage = replica_usage[replicas[replicaIndex]];
     }
     if (max_usage === 0)
         return;
-    for (replica = 0; replica < replicas.length; replica++) {
-        var replica_name = replicas[replica];
-        if (replica_usage[replica_name] === undefined)
+    for (replicaIndex = 0; replicaIndex < replicas.length; replicaIndex++) {
+        var replica = replicas[replicaIndex];
+        if (replica_usage[replica] === undefined)
             continue;
-        var relative = (replica_usage[replica_name] / max_usage) * 100;
-        var replica_object = $('.replica_name_' + replica_name);
-        replica_object.html('<b>' + replica_name +
-            ':</b> ' + Math.round(relative) + '%');
-        if (relative < 98 && !replica_object.hasClass('critical')) {
-            $('#grid_replica_' + replica_name).addClass('warning');
-            replica_object.addClass('warning');
+        var relative = (replica_usage[replica] / max_usage) * 100;
+
+        var relativeUsagePercent = Math.round(relative);
+        updateStateForReplica(replica, {relativeUsagePercent: relativeUsagePercent})
+
+        var severity = getStateForReplica(replica).maximumWarningSeverity;
+
+        // If a replica's relativeUsagePercent is lagging behind the other replicas, it may be experiencing issues, so warn
+        if (relative < 98 && severity !== "critical") {
+            updateStateForReplica(replica, {maximumWarningSeverity: "warning"})
         }
     }
 }
 
+// TODO: Remove replica_status global
+// This global is updated through the process of generating the status display.
+// It is the maximum severity of all the status warnings for a replica.
 var replica_status;
 
 function update_status(replica) {
     return function (status) {
         flush_status();
         running_status--;
-        replica_status = 'ok';
-        var html = '';
-        var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
-        html += '<div class="group">';
-        html += '<div class="name replica_name_' + replica + '"><b>' +
-            replica + '</b></div>';
-        html += button(address, 'http://' + address + '/_console');
-        html += '<div class="button" onclick="refresh(\'' + replica +
-            '\');"><b>refresh</b></div>';
-        html += '</div>';
-        html += '<div class="group">';
+        
+        updateStateForReplica(replica, {
+            requestResult: "success", 
+            status: status, 
+            maximumWarningSeverity: "ok", 
+            updating: false
+        });
 
-        html += button('sync', '/_sync/' + replica, true);
-        html += hover_help(
-            metric('sync status', status.sync_status, 0, 0, null,
-                status.sync_status.indexOf('failed') === 0 ? 1 : 0),
-            sync_status_help(status.sync_status));
-
-        html += button('purge', '/_purge/' + replica, true);
-        html += hover_help(
-            metric('purge status', status.purge_status, 0, 0, null,
-                status.purge_status.indexOf('failed') === 0 ? 1 : 0),
-            purge_status_help(status.purge_status));
-
-        html += button('buffer', '/_buffer/' + replica, true);
-        html += hover_help(
-            metric('buffer status', status.buffer_status, 0, 0, null,
-                status.buffer_status.indexOf('failed') === 0 ? 1 : 0),
-            buffer_status_help(status.buffer_status));
-
-        html += '</div>';
-        html += '<div class="group">';
         summary['replica events']['values'][replica] = 0;
-        html += iterate_sorted_object(status.replicas,
-            replica_metrics(replica));
+        iterate_sorted_object(status.replicas, update_replica_metrics(replica));
+
         summary['cluster events']['values'][replica] = 0;
-        html += iterate_sorted_object(status.clusters,
-            cluster_metrics(replica));
-        html += '</div>';
+        iterate_sorted_object(status.clusters, update_cluster_metrics(replica));
+        
+        if ('store_disk' in status) update_store_disk_metrics(replica, status.store_disk);
 
-        html += '<div class="group">';
-        html += hover_help(iterate_sorted_object(status.events, event_metrics),
-            'The &lt;current&gt;/&lt;max&gt;/&lt;total&gt; number of events ' +
-            'this replica has created.');
-        html += '</div>';
-
-        if ('index_sqlite' in status) {
-            html += '<div class="group">';
-            html += index_sqlite_metrics(replica, status.index_sqlite);
-            html += '</div>';
-        }
-
-        if ('store_disk' in status) {
-            html += '<div class="group">';
-            html += store_disk_metrics(replica, status.store_disk);
-            html += '</div>';
-        }
-
-        $('#replica_' + replica).html(html);
-        $('#replica_' + replica).removeClass('warning');
-        update_replica_status(replica, replica_status);
         update_summary();
+
         update_replica_usage(status.cluster, status.bucket);
-    };
+
+        // TODO: Remove this when full Mithril changeover
+        setTimeout(m.redraw, 0);
+    }
+}
+
+function generate_replica_status_success_div(replica) {
+    // TODO: This replica_status global is updated as a side effect of generating displays for metrics
+    replica_status = 'ok';
+    var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
+    var status = getStateForReplica(replica).status;
+    var sync_status_severity = (status.sync_status || "").indexOf('failed') === 0 ? 1 : 0;
+    var purge_status_severity = (status.purge_status || "").indexOf('failed') === 0 ? 1 : 0;
+    var buffer_status_severity = (status.buffer_status || "").indexOf('failed') === 0 ? 1 : 0;
+    var result = [
+        m(".group",
+            getReplicaLabel(replica, "name"),
+            button(address, 'http://' + address + '/_console'),
+            m(".button", {
+                onclick: refresh.bind(null, replica)
+            }, m("b", "refresh"))
+        ),
+        m(".group",
+            button('sync', '/_sync/' + replica, true),
+            hover_help(
+                metric('sync status', status.sync_status, 0, 0, null, sync_status_severity),
+                sync_status_help(status.sync_status),
+            ),
+
+            button('purge', '/_purge/' + replica, true),
+            hover_help(
+                metric('purge status', status.purge_status, 0, 0, null, purge_status_severity),
+                purge_status_help(status.purge_status)
+            ),
+
+            button('buffer', '/_buffer/' + replica, true),
+            hover_help(
+                metric('buffer status', status.buffer_status, 0, 0, null, buffer_status_severity),
+                buffer_status_help(status.buffer_status)
+            )
+        ),
+
+        m(".group",
+            iterate_sorted_object(status.replicas, replica_metrics(replica)),
+            iterate_sorted_object(status.clusters, cluster_metrics(replica))
+        ),
+
+        m(".group",
+            hover_help(
+                iterate_sorted_object(status.events, event_metrics),
+                'The &lt;current&gt;/&lt;max&gt;/&lt;total&gt; number of events this replica has created.'
+            )
+        ),
+
+        ('index_sqlite' in status) ? m(".group", index_sqlite_metrics(replica, status.index_sqlite)) : [],
+        ('store_disk' in status) ? m(".group", store_disk_metrics(replica, status.store_disk)) : []
+    ];
+
+    updateStateForReplica(replica, {maximumWarningSeverity: replica_status});
+    return result;
 }
 
 function sync_status_help(status) {
@@ -633,75 +755,90 @@ function buffer_status_help(status) {
             'that could be buffered during this run.';
 }
 
-function update_replica_status(replica, replica_status) {
-    $('#grid_replica_' + replica).removeClass().addClass(
-        'grid_replica ' + replica_status);
-    $('div.replica_name_' + replica).removeClass().addClass(
-        'name replica_name_' + replica + ' ' + replica_status);
-}
-
 function index_sqlite_metrics(replica, status) {
-    var html = '';
-    html += metric('sqlite database', status.database);
-    html += hover_help(
-        usage_metric('sqlite size', status.max_size, status.size, 60, 80, 1024),
-        'The &lt;used&gt;/&lt;total&gt; amount of disk space for the index.');
-    html += hover_help(
-        metric('sqlite queue size', status.queue_size, 10, 20),
-        'The number of events in the index thread queue.');
-    return html;
+    return [
+        metric('sqlite database', status.database),
+        hover_help(
+            usage_metric('sqlite size', status.max_size, status.size, 60, 80, 1024),
+            'The &lt;used&gt;/&lt;total&gt; amount of disk space for the index.'
+        ),
+        hover_help(
+            metric('sqlite queue size', status.queue_size, 10, 20),
+            'The number of events in the index thread queue.'
+        )
+    ];
 }
 
-function store_disk_metrics(replica, status) {
-    var html = '';
-    html += metric('disk path', status.path);
-    html += hover_help(
-        usage_metric('disk space', status.total_space,
-            status.total_space - status.free_space, 60, 80, 1024),
-        'The &lt;used&gt;/&lt;total&gt; amount of disk space.');
+function update_store_disk_metrics(replica, status) {
     summary['disk space']['values'][status.device_id] = 
         [status.total_space - status.free_space, status.total_space];
-    html += hover_help(
-        usage_metric('disk inodes', status.total_inodes,
-            status.total_inodes - status.free_inodes, 60, 80, 1000),
-        'The &lt;used&gt;/&lt;total&gt; number of disk inodes.');
     summary['disk inodes']['values'][status.device_id] = 
         [status.total_inodes - status.free_inodes, status.total_inodes];
     replica_usage[replica] = status.total_inodes - status.free_inodes;
-    html += hover_help(
-        metric('disk queue size', status.queue_size, 10, 20),
-        'The number of events in the disk thread queue.');
-    return html;
+}
+
+function store_disk_metrics(replica, status) {
+    return [
+        metric('disk path', status.path),
+        hover_help(
+            usage_metric('disk space', status.total_space,
+                status.total_space - status.free_space, 60, 80, 1024),
+            'The &lt;used&gt;/&lt;total&gt; amount of disk space.'
+        ),
+        hover_help(
+            usage_metric('disk inodes', status.total_inodes,
+                status.total_inodes - status.free_inodes, 60, 80, 1000),
+            'The &lt;used&gt;/&lt;total&gt; number of disk inodes.'
+        ),
+        hover_help(
+            metric('disk queue size', status.queue_size, 10, 20),
+            'The number of events in the disk thread queue.'
+        )
+    ];
+}
+
+function update_replica_metrics(summary_replica) {
+    return function (replica, status) {
+        if ('events' in status) {
+            summary['replica events']['values'][summary_replica] += status.events;
+        }
+    };
 }
 
 function replica_metrics(summary_replica) {
     return function (replica, status) {
-        var html = '';
-        if ('events' in status) {
-            html += hover_help(
-                metric(replica + ' events',
-                    status.buffer_events + '/' + status.events,
-                    config.clblob.client.replica_event_buffer_size,
-                    config.clblob.client.replica_event_buffer_size * 10,
-                    1000, status.events),
-                'The number of &lt;buffered&gt;/&lt;total&gt; events queued ' +
-                    'up to go to replica ' + replica + '.');
-            summary['replica events']['values'][summary_replica] += status.events;
-        }
         var replica_retry = config.clblob.client.replica_retry;
-        if ('last_failed' in status && status.last_failed < replica_retry) {
-            html += metric(replica + ' failed', status.last_failed,
-                replica_retry, 0, null);
+        return [
+            ('events' in status) ?
+                hover_help(
+                    metric(replica + ' events',
+                        status.buffer_events + '/' + status.events,
+                        config.clblob.client.replica_event_buffer_size,
+                        config.clblob.client.replica_event_buffer_size * 10,
+                        1000, status.events),
+                    'The number of &lt;buffered&gt;/&lt;total&gt; events queued ' +
+                        'up to go to replica ' + replica + '.'
+                    ) :
+                [],
+            ('last_failed' in status && status.last_failed < replica_retry) ?
+                metric(replica + ' failed', status.last_failed, replica_retry, 0, null) :
+                []
+        ];
+    };
+}
+
+function update_cluster_metrics(replica) {
+    return function (cluster, status) {
+        if ('events' in status) {
+            summary['cluster events']['values'][replica] += status.events;
         }
-        return html;
     };
 }
 
 function cluster_metrics(replica) {
     return function (cluster, status) {
-        var html = '';
         if ('events' in status) {
-            html += hover_help(
+            return hover_help(
                 metric('cluster ' + cluster + ' events',
                     status.buffer_events + '/' + status.events,
                     config.clblob.client.cluster_event_buffer_size,
@@ -709,9 +846,8 @@ function cluster_metrics(replica) {
                     1000, status.events),
                 'The number of &lt;buffered&gt;/&lt;total&gt; events queued ' +
                     'up to go to cluster ' + cluster + '.');
-            summary['cluster events']['values'][replica] += status.events;
         }
-        return html;
+        return [];
     };
 }
 
@@ -722,57 +858,68 @@ function event_metrics(event, status) {
 }
 
 function update_status_fail(replica) {
-    return function (data) {
+    return function (status) {
         flush_status();
         running_status--;
-        var html = '';
-        var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
-        html += '<div class="group">' +
-            '<div class="name replica_name_' + replica + '"><b>' + replica +
-            '</b></div>' +
-            button(address, 'http://' + address + '/_console') +
-            metric('failed', data.statusText, 0, 0, null, 1) +
-            '</div>';
+        updateStateForReplica(replica, {
+            requestResult: "error", 
+            status: status, 
+            maximumWarningSeverity: "critical", 
+            updating: false
+        });
+        // TODO: Remove this when full Mithril changeover
+        setTimeout(m.redraw, 0);
+    }
+}
 
-        $('#replica_' + replica).html(html);
-        $('#replica_' + replica).addClass('warning');
-        update_replica_status(replica, 'critical');
-    };
+function generate_replica_status_fail_div(replica) {
+    var address = allReplicasByName[replica].ip + ':' + allReplicasByName[replica].port;
+    var status = getStateForReplica(replica).status;
+
+    return m(".group",
+        getReplicaLabel(replica, "name"),
+        button(address, 'http://' + address + '/_console'),
+        metric('failed', status.statusText, 0, 0, null, 1)
+    );
 }
 
 function button(name, url, background) {
+    // This could be simplified to return one vdom node with an if statement to choose function action
     if (background) {
-        return '<div class="button" onclick="$.ajax(' +
-            "{url: '" + url + "', type: 'GET', timeout: replica_timeout});" +
-            '"><b>' + name + '</b></div>';
+        return m(".button", {
+            onclick: function() {
+                $.ajax({url: url, type: 'GET', timeout: replica_timeout, success: m.redraw, error: m.redraw});
+            }
+        }, m("b", name));
     }
-    return '<div class="button" onclick="' +
-        "location.href='" + url + "'" +
-        '"><b>' + name + '</b></div>';
+    return m(".button", {
+        onclick: function() {
+            location.href = url;
+        }
+    }, m("b", name));
 }
 
 function metric(name, value, warning, critical, factor, notify_value) {
     if (notify_value === undefined)
         notify_value = value;
     var notify = get_notify_class(notify_value, warning, critical);
-    return '<div class="metric' + notify + '"><b>' + name + ':</b> ' +
-        si_prefix(value, factor) + '</div>';
+    return m(".metric." + notify, m("b", name + ":"), si_prefix(value, factor));
 }
 
 function usage_metric(name, total, used, warning, critical, factor) {
     var used_percent = Math.round((used / total) * 100);
-    return metric(name, si_prefix(used, factor) + '/' +
-        si_prefix(total, factor) + ' (' + used_percent + '%)', warning,
-        critical, null, used_percent);
+    return metric(
+        name, 
+        si_prefix(used, factor) + '/' + si_prefix(total, factor) + ' (' + used_percent + '%)', 
+        warning,
+        critical,
+        null,
+        used_percent
+    );
 }
 
 function hover_help(content, help_text) {
-    return '<span class="hover_help_wrapper">' + content +
-        '<div class="hover_help">' + help_text + '</div></span>';
-}
-
-function m_hover_help(content, help_text) {
-    return m("span.hover_help_wrapper", content, m(".hover_help", help_text));
+    return m("span.hover_help_wrapper", content, m(".hover_help", m.trust(help_text)));
 }
 
 function iterate_sorted_object(key_values, callback) {
@@ -781,38 +928,40 @@ function iterate_sorted_object(key_values, callback) {
     for (key in key_values)
         keys.push(key);
     keys.sort();
-    var html = '';
+    var result = [];
     for (key in keys) {
         key = keys[key];
-        html += callback(key, key_values[key]);
+        result.push(callback(key, key_values[key]));
     }
-    return html;
+    return result;
 }
 
+// TODO: Remove global use from this function
+// This function has a side-effect of updating a global replica_status with increasingly severe status
 function get_notify_class(value, warning, critical) {
     if (warning > critical) {
         if (value < critical) {
             replica_status = 'critical';
-            return ' critical';
+            return 'critical';
         }
         else if (value < warning) {
             if (replica_status !== 'critical')
                 replica_status = 'warning';
-            return ' warning';
+            return 'warning';
         }
     }
     else {
         if (value > critical) {
             replica_status = 'critical';
-            return ' critical';
+            return 'critical';
         }
         else if (value > warning) {
             if (replica_status !== 'critical')
                 replica_status = 'warning';
-            return ' warning';
+            return 'warning';
         }
     }
-    return '';
+    return 'normal';
 }
 
 var SI_PREFIXES_LARGE = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
@@ -888,8 +1037,8 @@ function body() {
         ]),
         key_help(),
         m("#grid", grid()),
-        m("#summary"),
-        m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),
+        m("#summary", generate_summary_div()),
+        m("#by_ip", { class: isByIPHidden ? "hide" : "" }, iterate_sorted_object(allReplicasByIP, combine_ips)),
         m("#main", main())
     ]);
 }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -271,7 +271,7 @@ function foreach_replica(callback, filter) {
             if ($('#replica_' + replica).hasClass('hide'))
                 continue;
         }
-        else if (filter && filter != replica)
+        else if (filter && filter !== replica)
             continue;
         callback(replica);
     }
@@ -280,28 +280,28 @@ function foreach_replica(callback, filter) {
 function handle_keypress(event) {
     if (event.ctrlKey)
         return;
-    if (event.which == 104) {
+    if (event.which === 104) {
         $('div.replica').addClass('hide');
         return;
     }
-    if (event.which == 72) {
+    if (event.which === 72) {
         $('div.replica').removeClass('hide');
         return;
     }
-    if (event.which == 73 || event.which == 105) {
+    if (event.which === 73 || event.which === 105) {
         $('#by_ip').toggleClass('hide');
         return;
     }
     var url;
     var upper_key = event.which & 95;
-    var filter = event.which == 32 || event.which >= 97;
-    if (upper_key == 82 || event.which == 32)
+    var filter = event.which === 32 || event.which >= 97;
+    if (upper_key === 82 || event.which === 32)
         url = null;
-    if (upper_key == 66)
+    if (upper_key === 66)
         url = '/_buffer/';
-    if (upper_key == 80)
+    if (upper_key === 80)
         url = '/_purge/';
-    if (upper_key == 83)
+    if (upper_key === 83)
         url = '/_sync/';
     if (url === undefined)
         return;
@@ -309,11 +309,11 @@ function handle_keypress(event) {
     event.preventDefault();
 
     var current = Math.round(new Date().getTime() / keypress_max_ms);
-    if (current == last_keypress)
+    if (current === last_keypress)
         return;
     last_keypress = current;
 
-    if (url != null) {
+    if (url !== null) {
         foreach_replica(function (replica) {
             $.ajax({url: url + replica, type: "GET", timeout: replica_timeout});
         }, filter);
@@ -400,18 +400,18 @@ function summary_metrics(name, details) {
     var usage = 0;
     var total = 0;
     var count = 0;
-    for (replica in details['values']) {
+    for (var replica in details['values']) {
         count++;
-        if (details['type'] == 'usage') {
+        if (details['type'] === 'usage') {
             usage += details['values'][replica][0];
             total += details['values'][replica][1];
         }
         else
             total += details['values'][replica];
     }
-    if (count == 0)
+    if (count === 0)
         return '';
-    if (details['type'] == 'usage')
+    if (details['type'] === 'usage')
         return hover_help(
             usage_metric(name, total, usage, 60, 80, details['factor']),
             details['help_text']);
@@ -422,17 +422,18 @@ function summary_metrics(name, details) {
 }
 
 function update_replica_usage(cluster, bucket) {
+    var replica;
     var replicas = config.clblob.client.clusters[cluster][bucket].replicas;
     var max_usage = 0;
-    for (var replica = 0; replica < replicas.length; replica++) {
+    for (replica = 0; replica < replicas.length; replica++) {
         if (max_usage < replica_usage[replicas[replica]])
             max_usage = replica_usage[replicas[replica]];
     }
-    if (max_usage == 0)
+    if (max_usage === 0)
         return;
-    for (var replica = 0; replica < replicas.length; replica++) {
+    for (replica = 0; replica < replicas.length; replica++) {
         var replica_name = replicas[replica];
-        if (replica_usage[replica_name] == undefined)
+        if (replica_usage[replica_name] === undefined)
             continue;
         var relative = (replica_usage[replica_name] / max_usage) * 100;
         var replica_object = $('.replica_name_' + replica_name);
@@ -467,19 +468,19 @@ function update_status(replica) {
         html += button('sync', '/_sync/' + replica, true);
         html += hover_help(
             metric('sync status', status.sync_status, 0, 0, null,
-                status.sync_status.indexOf('failed') == 0 ? 1 : 0),
+                status.sync_status.indexOf('failed') === 0 ? 1 : 0),
             sync_status_help(status.sync_status));
 
         html += button('purge', '/_purge/' + replica, true);
         html += hover_help(
             metric('purge status', status.purge_status, 0, 0, null,
-                status.purge_status.indexOf('failed') == 0 ? 1 : 0),
+                status.purge_status.indexOf('failed') === 0 ? 1 : 0),
             purge_status_help(status.purge_status));
 
         html += button('buffer', '/_buffer/' + replica, true);
         html += hover_help(
             metric('buffer status', status.buffer_status, 0, 0, null,
-                status.buffer_status.indexOf('failed') == 0 ? 1 : 0),
+                status.buffer_status.indexOf('failed') === 0 ? 1 : 0),
             buffer_status_help(status.buffer_status));
 
         html += '</div>';
@@ -515,39 +516,39 @@ function update_status(replica) {
         update_replica_status(replica, replica_status);
         update_summary();
         update_replica_usage(status.cluster, status.bucket);
-    }
+    };
 }
 
 function sync_status_help(status) {
-    if (status.indexOf('start delay') == 0)
+    if (status.indexOf('start delay') === 0)
         return 'Sync has not been run since server start.';
-    if (status.indexOf('failed') == 0)
+    if (status.indexOf('failed') === 0)
         return 'Sync failed to complete.';
-    if (status.indexOf('local checksums') == 0)
+    if (status.indexOf('local checksums') === 0)
         help = 'Sync is running and is currently computing a list of ' +
             'checksums for this replica.';
-    else if (status.indexOf('source checksums') == 0)
+    else if (status.indexOf('source checksums') === 0)
         help = 'Sync is running and is currently computing a list of ' +
             'checksums for a peer replica.';
-    else if (status.indexOf('diff checksums') == 0)
+    else if (status.indexOf('diff checksums') === 0)
         help = 'Sync is running and is currently comparing a list of ' +
             'checksums between this replica and a peer replica.';
-    else if (status.indexOf('local blobs') == 0)
+    else if (status.indexOf('local blobs') === 0)
         help = 'Sync is running and is currently getting a list of blobs ' +
             'for this replica.';
-    else if (status.indexOf('source blobs') == 0)
+    else if (status.indexOf('source blobs') === 0)
         help = 'Sync is running and is currently getting a list of blobs ' +
             'for a peer replica.';
-    else if (status.indexOf('diff blobs') == 0)
+    else if (status.indexOf('diff blobs') === 0)
         help = 'Sync is running and is currently comparing a list of blobs ' +
             'between this replica and a peer replica.';
-    else if (status.indexOf('put') == 0)
+    else if (status.indexOf('put') === 0)
         help = 'Sync is running and is currently grabbing a blob from a ' +
             'peer to put into this replica.';
-    else if (status.indexOf('delete') == 0)
+    else if (status.indexOf('delete') === 0)
         help = 'Sync is running and is currently updating the delete time ' +
             'for a blob in this replica.';
-    else if (status.indexOf('synced') == 0)
+    else if (status.indexOf('synced') === 0)
         help = 'Sync is done running.';
     else
         help = 'Status of current/last sync operation.';
@@ -556,20 +557,20 @@ function sync_status_help(status) {
 }
 
 function purge_status_help(status) {
-    if (status.indexOf('start delay') == 0)
+    if (status.indexOf('start delay') === 0)
         return 'Purge has not been run since server start.';
-    if (status.indexOf('failed') == 0)
+    if (status.indexOf('failed') === 0)
         return 'Purge failed to complete.';
-    if (status.indexOf('get_expired') == 0)
+    if (status.indexOf('get_expired') === 0)
         help = 'Purge is running and is currently getting a list of expired ' +
             'blobs from the index.';
-    else if (status.indexOf('delete') == 0)
+    else if (status.indexOf('delete') === 0)
         help = 'Purge is running and is currently deleting an expired blob ' +
             'from disk.';
-    else if (status.indexOf('delete_expired') == 0)
+    else if (status.indexOf('delete_expired') === 0)
         help = 'Purge is running and is currently deleting expired blobs ' +
             'from the index.';
-    else if (status.indexOf('purged') == 0)
+    else if (status.indexOf('purged') === 0)
         help = 'Purge is done running.';
     else
         help = 'Status of current/last purge operation.';
@@ -578,17 +579,17 @@ function purge_status_help(status) {
 }
 
 function buffer_status_help(status) {
-    if (status.indexOf('start delay') == 0)
+    if (status.indexOf('start delay') === 0)
         return 'Buffer has not been run since server start.';
-    if (status.indexOf('failed') == 0)
+    if (status.indexOf('failed') === 0)
         help = 'Buffer failed to complete.';
-    if (status.indexOf('get_replica_events') == 0)
+    if (status.indexOf('get_replica_events') === 0)
         help = 'Buffer is running and is currently getting a list of ' +
             'replica events from the index to buffer into memory.';
-    else if (status.indexOf('get_cluster_events') == 0)
+    else if (status.indexOf('get_cluster_events') === 0)
         help = 'Buffer is running and is currently getting a list of ' +
             'cluster events from the index to buffer into memory.';
-    else if (status.indexOf('buffered') == 0)
+    else if (status.indexOf('buffered') === 0)
         help = 'Buffer is done running.';
     else
         help = 'Status of current/last buffer operation.';
@@ -630,7 +631,7 @@ function store_disk_metrics(replica, status) {
         'The &lt;used&gt;/&lt;total&gt; number of disk inodes.');
     summary['disk inodes']['values'][status.device_id] = 
         [status.total_inodes - status.free_inodes, status.total_inodes];
-    replica_usage[replica] = status.total_inodes - status.free_inodes
+    replica_usage[replica] = status.total_inodes - status.free_inodes;
     html += hover_help(
         metric('disk queue size', status.queue_size, 10, 20),
         'The number of events in the disk thread queue.');
@@ -657,7 +658,7 @@ function replica_metrics(summary_replica) {
                 replica_retry, 0, null);
         }
         return html;
-    }
+    };
 }
 
 function cluster_metrics(replica) {
@@ -675,7 +676,7 @@ function cluster_metrics(replica) {
             summary['cluster events']['values'][replica] += status.events;
         }
         return html;
-    }
+    };
 }
 
 function event_metrics(event, status) {
@@ -701,7 +702,7 @@ function update_status_fail(replica) {
         $('#replica_' + replica).html(html);
         $('#replica_' + replica).addClass('warning');
         update_replica_status(replica, 'critical');
-    }
+    };
 }
 
 function button(name, url, background) {
@@ -737,11 +738,12 @@ function hover_help(content, help_text) {
 
 function iterate_sorted_object(key_values, callback) {
     var keys = [];
-    for (var key in key_values)
+    var key;
+    for (key in key_values)
         keys.push(key);
     keys.sort();
     var html = '';
-    for (var key in keys) {
+    for (key in keys) {
         key = keys[key];
         html += callback(key, key_values[key]);
     }
@@ -755,7 +757,7 @@ function get_notify_class(value, warning, critical) {
             return ' critical';
         }
         else if (value < warning) {
-            if (replica_status != 'critical')
+            if (replica_status !== 'critical')
                 replica_status = 'warning';
             return ' warning';
         }
@@ -766,7 +768,7 @@ function get_notify_class(value, warning, critical) {
             return ' critical';
         }
         else if (value > warning) {
-            if (replica_status != 'critical')
+            if (replica_status !== 'critical')
                 replica_status = 'warning';
             return ' warning';
         }

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -195,13 +195,9 @@ function update_config(data) {
     }
 
     $('#by_ip').html(iterate_sorted_object(by_ip, combine_ips));
-    $('#main').html(main());
 
-    $('div.replica').addClass('hide');
     $(document).keypress(handle_keypress);
     refresh();
-
-    m.redraw();
 }
 
 function grid() {
@@ -238,49 +234,52 @@ function grid() {
 }
 
 function main() {
-    var main = '';
-
-    for (var cluster = 0; cluster < clusters.length; cluster++) {
-        main += '<div id="cluster_' + cluster + '" class="cluster">' +
-            '<div class="group">' +
-            '<div class="name"><b>cluster ' + cluster + '</b></div>' +
-            '</div>';
-
-        var buckets = clusters[cluster];
-        for (var bucket = 0; bucket < buckets.length; bucket++) {
-            main += '<div id="bucket_' + cluster + '_' + bucket +
-                '" class="bucket">' +
-                '<div class="group clickable" onclick="' +
-                '$(this).siblings(\'div.replica\').toggleClass(\'hide\');">' +
-                '<div class="name"><b>bucket ' + bucket + '</b></div>' +
-                metric('write weight', buckets[bucket].write_weight, 0, 0,
-                    null, 0);
-
-            var replicas = buckets[bucket].replicas;
-            for (var replica = 0; replica < replicas.length; replica++) {
-                main += '<div class="metric replica_name_' + replicas[replica] +
-                    '"><b>' + replicas[replica] + '</b></div>';
-            }
-            main += replica_main(replicas);
-        }
-        main += '</div>';
-    }
-
-    return main;
+    return clusters.map(function (cluster, clusterIndex) {
+        return m(".cluster#cluster_" + clusterIndex,
+            m(".group",
+                m(".name",
+                    m("b", "cluster " + clusterIndex)
+                )
+            ),
+            cluster.map(function (bucket, bucketIndex) {
+                return m(".bucket#bucket_" + clusterIndex + '_' + bucketIndex,
+                    m(".group.clickable", 
+                        {
+                            onclick: function(event) {
+                                // TODO: store this state in domain not DOM
+                                $(this).siblings('div.replica').toggleClass('hide');
+                            }
+                        }, 
+                        m(".name",
+                            m("b", "bucket " + bucketIndex)
+                        ),
+                        // TODO: Remove this use of m.trust
+                        m.trust(metric('write weight', bucket.write_weight, 0, 0, null, 0)),
+                        bucket.replicas.map(function (replica, replicaIndex) {
+                            return m(".metric#replica_name_" + replica,
+                                m("b", replica)
+                            )
+                        }),
+                    ),
+                    replica_main(bucket.replicas)
+                )
+            })
+        )
+    });
 }
 
 function replica_main(replicas) {
-    var replica_main = '';
-
-    for (var replica = 0; replica < replicas.length; replica++) {
-        replica_main += '<div id="replica_' + replicas[replica] +
-            '" class="replica">' +
-            '<div class="group">' +
-            '<div class="name replica_name_' + replicas[replica] +
-            '"><b>' + replicas[replica] + '</b></div>' +
-            '</div></div>';
-    }
-    return '</div>' + replica_main + '</div>';
+    return replicas.map(function (replica, replicaIndex) {
+        // TODO: Use of css class .hide here is problematical 
+        // since we're relying on vdom not putting it back while jQuery interacts with classes
+        return m(".replica.hide#replica_" + replica,
+            m(".group", 
+                m(".name#replica_name_" + replica,
+                    m("b", replica)
+                )
+            )
+        )
+    });
 }
 
 function combine_ips(ip, ports) {
@@ -873,7 +872,7 @@ function body() {
         m("#header", [
             m("h1", m.trust("&#9774;"), " craigslist blob console"),
             m("a.clickable", {
-                onclick: function() { isHelpHidden = !isHelpHidden; console.log("isHelpHidden", isHelpHidden); },
+                onclick: function() { isHelpHidden = !isHelpHidden; },
             }, [
                 m("b", "shortcuts")
             ]),
@@ -888,7 +887,7 @@ function body() {
         m("#grid", grid()),
         m("#summary"),
         m("#by_ip", { class: isByIPHidden ? "hide" : "" } ),
-        m("#main")
+        m("#main", main())
     ]);
 }
         </script>

--- a/clblob/console.html
+++ b/clblob/console.html
@@ -175,12 +175,40 @@ var queued_status = [];
 var replica_usage = {};
 var replica_timeout = 2000;
 
+var clusters = [];
+var by_ip = {};
+
 function update_config(data) {
     config = data;
+    clusters = config.clblob.client.clusters;
+    
+    for (var cluster = 0; cluster < clusters.length; cluster++) {
+        var buckets = clusters[cluster];
+        for (var bucket = 0; bucket < buckets.length; bucket++) {
+            var replicas = buckets[bucket].replicas;
+            for (var replica = 0; replica < replicas.length; replica++) {
+                var ip = config.clblob.client.replicas[replicas[replica]].ip;
+                var port = config.clblob.client.replicas[replicas[replica]].port;
+                if (!by_ip[ip]) by_ip[ip] = {};
+                by_ip[ip][port] = replicas[replica];
+                refresh_replicas.push(replicas[replica]);
+            }
+        }
+    }
+
+    $('#grid').html(grid());
+    $('#by_ip').html(iterate_sorted_object(by_ip, combine_ips));
+    $('#main').html(main());
+
+    $('div.replica').addClass('hide');
+    $(document).keypress(handle_keypress);
+    refresh();
+
+    m.redraw();
+}
+
+function grid() {
     var grid = '';
-    var main = '';
-    var by_ip = {};
-    var clusters = config.clblob.client.clusters;
 
     grid += '<div class="group">';
     for (var cluster = 0; cluster < clusters.length; cluster++) {
@@ -190,26 +218,12 @@ function update_config(data) {
             '</div>' +
             '<div class="group">';
 
-        main += '<div id="cluster_' + cluster + '" class="cluster">' +
-            '<div class="group">' +
-            '<div class="name"><b>cluster ' + cluster + '</b></div>' +
-            '</div>';
-
         var buckets = clusters[cluster];
         for (var bucket = 0; bucket < buckets.length; bucket++) {
             grid += '<div class="grid_bucket">' +
                 '<div class="grid_bucket_number">' + bucket + '</div>';
 
-            main += '<div id="bucket_' + cluster + '_' + bucket +
-                '" class="bucket">' +
-                '<div class="group clickable" onclick="' +
-                '$(this).siblings(\'div.replica\').toggleClass(\'hide\');">' +
-                '<div class="name"><b>bucket ' + bucket + '</b></div>' +
-                metric('write weight', buckets[bucket].write_weight, 0, 0,
-                    null, 0);
-
             var replicas = buckets[bucket].replicas;
-            var replica_main = '';
             for (var replica = 0; replica < replicas.length; replica++) {
                 grid += hover_help(
                     '<a href="#bucket_' + cluster + '_' + bucket + '" ' +
@@ -219,39 +233,60 @@ function update_config(data) {
                     '<div id="grid_replica_' + replicas[replica] +
                     '" class="grid_replica"></div></a>',
                     replicas[replica]);
-
-                main += '<div class="metric replica_name_' + replicas[replica] +
-                    '"><b>' + replicas[replica] + '</b></div>';
-
-                replica_main += '<div id="replica_' + replicas[replica] +
-                    '" class="replica">' +
-                    '<div class="group">' +
-                    '<div class="name replica_name_' + replicas[replica] +
-                    '"><b>' + replicas[replica] + '</b></div>' +
-                    '</div></div>';
-
-                var ip = config.clblob.client.replicas[replicas[replica]].ip;
-                var port = config.clblob.client.replicas[replicas[replica]].port;
-                if (!by_ip[ip])
-                    by_ip[ip] = {};
-                by_ip[ip][port] = replicas[replica];
-
-                refresh_replicas.push(replicas[replica]);
             }
             grid += '</div>';
-            main += '</div>' + replica_main + '</div>';
         }
         grid += '</div></div>';
-        main += '</div>';
     }
     grid += '</div>';
 
-    $('#grid').html(grid);
-    $('#by_ip').html(iterate_sorted_object(by_ip, combine_ips));
-    $('#main').html(main);
-    $('div.replica').addClass('hide');
-    $(document).keypress(handle_keypress);
-    refresh();
+   return grid;
+}
+
+function main() {
+    var main = '';
+
+    for (var cluster = 0; cluster < clusters.length; cluster++) {
+        main += '<div id="cluster_' + cluster + '" class="cluster">' +
+            '<div class="group">' +
+            '<div class="name"><b>cluster ' + cluster + '</b></div>' +
+            '</div>';
+
+        var buckets = clusters[cluster];
+        for (var bucket = 0; bucket < buckets.length; bucket++) {
+            main += '<div id="bucket_' + cluster + '_' + bucket +
+                '" class="bucket">' +
+                '<div class="group clickable" onclick="' +
+                '$(this).siblings(\'div.replica\').toggleClass(\'hide\');">' +
+                '<div class="name"><b>bucket ' + bucket + '</b></div>' +
+                metric('write weight', buckets[bucket].write_weight, 0, 0,
+                    null, 0);
+
+            var replicas = buckets[bucket].replicas;
+            for (var replica = 0; replica < replicas.length; replica++) {
+                main += '<div class="metric replica_name_' + replicas[replica] +
+                    '"><b>' + replicas[replica] + '</b></div>';
+            }
+            main += replica_main(replicas);
+        }
+        main += '</div>';
+    }
+
+    return main;
+}
+
+function replica_main(replicas) {
+    var replica_main = '';
+
+    for (var replica = 0; replica < replicas.length; replica++) {
+        replica_main += '<div id="replica_' + replicas[replica] +
+            '" class="replica">' +
+            '<div class="group">' +
+            '<div class="name replica_name_' + replicas[replica] +
+            '"><b>' + replicas[replica] + '</b></div>' +
+            '</div></div>';
+    }
+    return '</div>' + replica_main + '</div>';
 }
 
 function combine_ips(ip, ports) {
@@ -835,7 +870,7 @@ function key_help() {
     );
 }
 
-function main() {
+function body() {
     return m("div", [
         m("#header", [
             m("h1", m.trust("&#9774;"), " craigslist blob console"),
@@ -861,6 +896,6 @@ function main() {
         </script>
     </head>
     <body>
-        <script>m.mount(document.body, {view: main});</script>
+        <script>m.mount(document.body, {view: body});</script>
     </body>
 </html>


### PR DESCRIPTION
The complex clblob console single-page application is hard to understand and extend in jQuery. This PR improves that situation by converting console.html to use Mithril.js instead. This is also a proof-of-concept for using Mithril in other Craigslist operations.

=== More details

Mithril.js is a vdom library similar to React but lighter-weight, hopefully reflecting Craigslist's minimalist design approach. While React is more popular, it has a bigger footprint, is somewhat slower, and most importantly comes with the Facebook Patents clause as a potential risk. 

The advantage of Mithril over jQuery here is to make a single-page application easier to understand, maintain, and enhance. Previously, jQuery was used to store application state in HTML and CSS which makes application state harder to reason about. After the conversion, there is now essentially a model of the application state (as globals) which is re-rendered on every change from a UI action, network request, or timeout. Behind the scenes Mithril.js optimized the re-rendering to minimize DOM updates.

The Mithril vdom approach is similar to how many video games are implemented. It is much easier to reason about how state turns into display items through a one-way conversion algorithm than it is to reason about how display items get modified here and there by snippets of code (some of which are even in strings passed to event handlers) which store application state scattered throughout the DOM.

Every commit here results in a runnable application -- although there was a CSS update issue introduced in the middle which was fixed later. Most commits are small steps except for one big one near the end. Retaining the commit history rather than squashing this into one commit makes the conversion process easier to follow as a learning experiences about how to convert other jQuery-based applications to Mithril.

Currently this code loads Mithril from a CDN. In production Mithril should be loaded locally for security reasons, but I was not sure how Craigslist would need this done since jQuery is defined in python-clcommon and not in this repo. The simplest approach is just to add Mithril 1.1.1 to this repo.

There is a TODO item remaining for optimization. The code still retains using the replica_status global which is modified as a side-effect of the metric rendering function to determine a maximum warning severity level for the replica. The simplest upgrade approach was to keep that global for now and call part of the rendering process twice on request status updates, The rendering for the replica is called once to calculate the severity but the rendering itself is not used -- then the entire document is re-rendered with the correct maximum warning severity for the replica. This works, but it could be better.

A "nohide" CSS class and an "ok" CSS class was introduced into the output to represent default states for convenience of implementation and future styling, but otherwise the output should (ideally) be identical to the jQuery version. Those classes could be removed if desired with a little more work.

Future work might include splitting out the JavaScript code into a separate file, moving it into TypeScript to more clearly define the data model as a single class instance instead of a set of globals, and perhaps changing the CSS class approach to use Tachyons-css.

Obviously a big change like this would need a lot more testing before being used in production. I have only tested it on a developer machine with the "examples" cluster.conf file and without any significant file activity. Ideally there would be unit and functional test for this UI code. Mithril makes it possible to check fragments of vdom output against a standard in unit tests without having to actually generate DOM nodes in a real or phantom browser. But this is about all I have time for at the moment. That would also involve picking a testing framework (like Mocha) and introducing it into the repository. 

I can't quite say "it hovers much better now" because the console (by intent) still does essentially exactly what it did before -- it only works very differently under the hood in a non-visible way. So rather than upgrading to a hover car (yet), this change is like upgrading from a 2000s Toyota to a 2010s Tesla -- it has a small learning curve but it is hopefully worth it for ultimately lower operating and maintenance costs.

The big payoff of this conversion is in making it easier for the console application to "hover" in the future, like by:
* adding statistical graphs of replica performance over time
* displaying alternative views of replicas like by geographical locations 
* showing communication status between replicas
* changing the action divs to use real buttons or otherwise adding user feedback on clicking
* putting up toast messages when actions on replicas succeed or fail
* storing notes about replicas or other operator-generated information or plans
* supporting dynamic configuration file updates
* performing other status checks on replicas like adding and removing a test file
* making different versions of the console for users with specialized needs
* quickly trying out some new idea for clblob management
* supporting some crazy-sounding idea like a decentralized social semantic desktop

There are of course many vdoms out there. A list of vdoms I put together last year can be found here for comparison:
https://github.com/dojo/meta/issues/11#issuecomment-176790243

Mithril.js is just my favorite of all those for a combination of the implementation, the licensing, the primary author's design style, and the community. The documentation for Mithril.js can be found here: https://mithril.js.org